### PR TITLE
feat: export ptypeToArc4EncodedType function needed for stub implementation

### DIFF
--- a/src/awst_build/ptypes/for-export.ts
+++ b/src/awst_build/ptypes/for-export.ts
@@ -1,3 +1,4 @@
 /* This file aggregates all ptypes into a single export for external consumption of the compiler api */
-export * from './index'
+export { ptypeToArc4EncodedType } from '../arc4-util'
 export * from './arc4-types'
+export * from './index'


### PR DESCRIPTION
- export ptypeToArc4EncodedType function needed for stub implementation of encodeArc4, decodeArc4 functions