### PR TITLE
fix: define isArc4 as static propery to remove explicit version dependency by testing module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13544,7 +13544,7 @@
     },
     "packages/algo-ts/dist": {
       "name": "@algorandfoundation/algorand-typescript",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.6",
       "dev": true,
       "peerDependencies": {
         "tslib": "^2.6.2"

--- a/packages/algo-ts/package.json
+++ b/packages/algo-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algorandfoundation/algorand-typescript",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "This package contains definitions for the types which comprise Algorand TypeScript which can be compiled to run on the Algorand Virtual Machine using the Puya compiler.",
   "private": false,
   "main": "index.js",

--- a/packages/algo-ts/src/arc4/index.ts
+++ b/packages/algo-ts/src/arc4/index.ts
@@ -8,6 +8,8 @@ import { DeliberateAny } from '../typescript-helpers'
 export * from './encoded-types'
 
 export class Contract extends BaseContract {
+  static isArc4 = true
+
   override approvalProgram(): boolean {
     return true
   }

--- a/packages/algo-ts/src/base-contract.ts
+++ b/packages/algo-ts/src/base-contract.ts
@@ -3,6 +3,8 @@ import { uint64 } from './primitives'
 import { ConstructorFor } from './typescript-helpers'
 
 export abstract class BaseContract {
+  static isArc4 = false
+
   public abstract approvalProgram(): boolean | uint64
   public clearStateProgram(): boolean | uint64 {
     return true

--- a/src/puya/ensure-puya-exists.ts
+++ b/src/puya/ensure-puya-exists.ts
@@ -1,9 +1,9 @@
-import { sync as whichSync } from 'which'
+import which from 'which'
 import { EnvironmentError } from '../errors'
 
 export function ensurePuyaExists() {
   if (
-    whichSync('puya', {
+    which.sync('puya', {
       nothrow: true,
     })
   )


### PR DESCRIPTION
*Also*: 
- update import statement for `which` common js package  to avoid having to inline node module