### PR TITLE
refactor: remove extra functions from context manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13552,7 +13552,7 @@
     },
     "packages/algo-ts/dist": {
       "name": "@algorandfoundation/algorand-typescript",
-      "version": "1.0.0-beta.11",
+      "version": "1.0.0-beta.13",
       "dev": true,
       "peerDependencies": {
         "tslib": "^2.6.2"

--- a/packages/algo-ts/package.json
+++ b/packages/algo-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algorandfoundation/algorand-typescript",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.13",
   "description": "This package contains definitions for the types which comprise Algorand TypeScript which can be compiled to run on the Algorand Virtual Machine using the Puya compiler.",
   "private": false,
   "main": "index.js",

--- a/packages/algo-ts/src/box.ts
+++ b/packages/algo-ts/src/box.ts
@@ -1,4 +1,4 @@
-import { ctxMgr } from './execution-context'
+import { NoImplementation } from './impl/errors'
 import { bytes, uint64 } from './primitives'
 
 export type Box<TValue> = {
@@ -40,13 +40,13 @@ export type BoxRef = {
 }
 
 export function Box<TValue>(options: { key: bytes | string }): Box<TValue> {
-  return ctxMgr.instance.state.Box(options)
+  throw new NoImplementation()
 }
 
 export function BoxMap<TKey, TValue>(options: { keyPrefix: bytes | string }): BoxMap<TKey, TValue> {
-  return ctxMgr.instance.state.BoxMap(options)
+  throw new NoImplementation()
 }
 
 export function BoxRef(options: { key: bytes | string }): BoxRef {
-  return ctxMgr.instance.state.BoxRef(options)
+  throw new NoImplementation()
 }

--- a/packages/algo-ts/src/execution-context.ts
+++ b/packages/algo-ts/src/execution-context.ts
@@ -1,34 +1,9 @@
-import { Box, BoxMap, BoxRef, Contract, GlobalState, gtxn, itxn, LocalState } from '.'
+import { Contract } from '.'
 import { AbiMethodConfig, BareMethodConfig } from './arc4'
 
 export type ExecutionContext = {
   abiMetadata: {
     captureMethodConfig<T extends Contract>(contract: T, methodName: string, config?: AbiMethodConfig<T> | BareMethodConfig): void
-  }
-  gtxn: {
-    Transaction: typeof gtxn.Transaction
-    PaymentTxn: typeof gtxn.PaymentTxn
-    KeyRegistrationTxn: typeof gtxn.KeyRegistrationTxn
-    AssetConfigTxn: typeof gtxn.AssetConfigTxn
-    AssetTransferTxn: typeof gtxn.AssetTransferTxn
-    AssetFreezeTxn: typeof gtxn.AssetFreezeTxn
-    ApplicationTxn: typeof gtxn.ApplicationTxn
-  }
-  itxn: {
-    submitGroup: typeof itxn.submitGroup
-    payment: typeof itxn.payment
-    keyRegistration: typeof itxn.keyRegistration
-    assetConfig: typeof itxn.assetConfig
-    assetTransfer: typeof itxn.assetTransfer
-    assetFreeze: typeof itxn.assetFreeze
-    applicationCall: typeof itxn.applicationCall
-  }
-  state: {
-    GlobalState: typeof GlobalState
-    LocalState: typeof LocalState
-    Box: typeof Box
-    BoxMap: typeof BoxMap
-    BoxRef: typeof BoxRef
   }
 }
 

--- a/packages/algo-ts/src/gtxn.ts
+++ b/packages/algo-ts/src/gtxn.ts
@@ -1,4 +1,4 @@
-import { ctxMgr } from './execution-context'
+import { NoImplementation } from './impl/errors'
 import { uint64 } from './primitives'
 import type * as txnTypes from './transactions'
 
@@ -25,23 +25,23 @@ export interface ApplicationTxn extends txnTypes.ApplicationTxn {
 export type Transaction = PaymentTxn | KeyRegistrationTxn | AssetConfigTxn | AssetTransferTxn | AssetFreezeTxn | ApplicationTxn
 
 export function Transaction(groupIndex: uint64): Transaction {
-  return ctxMgr.instance.gtxn.Transaction(groupIndex)
+  throw new NoImplementation()
 }
 export function PaymentTxn(groupIndex: uint64): PaymentTxn {
-  return ctxMgr.instance.gtxn.PaymentTxn(groupIndex)
+  throw new NoImplementation()
 }
 export function KeyRegistrationTxn(groupIndex: uint64): KeyRegistrationTxn {
-  return ctxMgr.instance.gtxn.KeyRegistrationTxn(groupIndex)
+  throw new NoImplementation()
 }
 export function AssetConfigTxn(groupIndex: uint64): AssetConfigTxn {
-  return ctxMgr.instance.gtxn.AssetConfigTxn(groupIndex)
+  throw new NoImplementation()
 }
 export function AssetTransferTxn(groupIndex: uint64): AssetTransferTxn {
-  return ctxMgr.instance.gtxn.AssetTransferTxn(groupIndex)
+  throw new NoImplementation()
 }
 export function AssetFreezeTxn(groupIndex: uint64): AssetFreezeTxn {
-  return ctxMgr.instance.gtxn.AssetFreezeTxn(groupIndex)
+  throw new NoImplementation()
 }
 export function ApplicationTxn(groupIndex: uint64): ApplicationTxn {
-  return ctxMgr.instance.gtxn.ApplicationTxn(groupIndex)
+  throw new NoImplementation()
 }

--- a/packages/algo-ts/src/itxn.ts
+++ b/packages/algo-ts/src/itxn.ts
@@ -1,5 +1,5 @@
 import { OnCompleteAction } from './arc4'
-import { ctxMgr } from './execution-context'
+import { NoImplementation } from './impl/errors'
 import { bytes, uint64 } from './primitives'
 import type { Account, Application, Asset } from './reference'
 import type * as txnTypes from './transactions'
@@ -174,23 +174,23 @@ export type AssetFreezeItxnParams = InnerTransaction<AssetFreezeFields, AssetFre
 export type ApplicationCallItxnParams = InnerTransaction<ApplicationCallFields, ApplicationInnerTxn>
 
 export function submitGroup<TFields extends InnerTxnList>(...transactionFields: TFields): TxnFor<TFields> {
-  return ctxMgr.instance.itxn.submitGroup(...transactionFields)
+  throw new NoImplementation()
 }
 export function payment(fields: PaymentFields): PaymentItxnParams {
-  return ctxMgr.instance.itxn.payment(fields)
+  throw new NoImplementation()
 }
 export function keyRegistration(fields: KeyRegistrationFields): KeyRegistrationItxnParams {
-  return ctxMgr.instance.itxn.keyRegistration(fields)
+  throw new NoImplementation()
 }
 export function assetConfig(fields: AssetConfigFields): AssetConfigItxnParams {
-  return ctxMgr.instance.itxn.assetConfig(fields)
+  throw new NoImplementation()
 }
 export function assetTransfer(fields: AssetTransferFields): AssetTransferItxnParams {
-  return ctxMgr.instance.itxn.assetTransfer(fields)
+  throw new NoImplementation()
 }
 export function assetFreeze(fields: AssetFreezeFields): AssetFreezeItxnParams {
-  return ctxMgr.instance.itxn.assetFreeze(fields)
+  throw new NoImplementation()
 }
 export function applicationCall(fields: ApplicationCallFields): ApplicationCallItxnParams {
-  return ctxMgr.instance.itxn.applicationCall(fields)
+  throw new NoImplementation()
 }

--- a/packages/algo-ts/src/state.ts
+++ b/packages/algo-ts/src/state.ts
@@ -1,4 +1,4 @@
-import { ctxMgr } from './execution-context'
+import { NoImplementation } from './impl/errors'
 import { bytes } from './primitives'
 import { Account } from './reference'
 
@@ -13,7 +13,7 @@ export type GlobalStateOptions<ValueType> = { key?: bytes | string; initialValue
 
 /** A single key in global state */
 export function GlobalState<ValueType>(options?: GlobalStateOptions<ValueType>): GlobalState<ValueType> {
-  return ctxMgr.instance.state.GlobalState(options)
+  throw new NoImplementation()
 }
 
 /** A value saved in local state */
@@ -29,5 +29,5 @@ export type LocalState<ValueType> = {
 
 /** A single key in local state */
 export function LocalState<ValueType>(options?: { key?: bytes | string }): LocalState<ValueType> {
-  return ctxMgr.instance.state.LocalState(options)
+  throw new NoImplementation()
 }


### PR DESCRIPTION
refactor: remove extra functions from context manager as stub implementation has moved to import replacement pattern for those