### PR TITLE
fix: add tslib as non dev dependency to puya-ts package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "glob": "^11.0.0",
         "minimatch": "^10.0.1",
         "polytype": "^0.17.0",
+        "tslib": "^2.6.2",
         "typescript": "5.7.2",
         "upath": "^2.0.1",
         "which": "^5.0.0",
@@ -13124,7 +13125,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "typescript": "5.7.2",
     "upath": "^2.0.1",
     "which": "^5.0.0",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "tslib": "^2.6.2"
   },
   "overrides": {
     "cross-spawn": "7.0.6",


### PR DESCRIPTION
# Proposed changes

Executing puya ts via npx results in:
```
node:internal/modules/esm/resolve:839
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'tslib' imported from /Users/aorumbayev/.nvm/versions/node/v22.9.0/lib/node_modules/@algorandfoundation/puya-ts/bin/run-cli.mjs
    at packageResolve (node:internal/modules/esm/resolve:839:9)
    at moduleResolve (node:internal/modules/esm/resolve:908:18)
    at defaultResolve (node:internal/modules/esm/resolve:1038:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:557:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:525:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:246:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:126:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```

The following adds tslib explicitly as a non dev dependency.