### PR TITLE
fix: native property of static bytes in puya-ts was throwing unexpected type error

### DIFF
--- a/src/awst_build/ptypes/register.ts
+++ b/src/awst_build/ptypes/register.ts
@@ -367,6 +367,15 @@ export function registerPTypes(typeRegistry: TypeRegistry) {
   typeRegistry.register({ ptype: UFixedNxMClass, singletonEb: UFixedNxMClassBuilder })
   typeRegistry.registerGeneric({ generic: UFixedNxMGeneric, ptype: UFixedNxMType, instanceEb: UFixedNxMExpressionBuilder })
   typeRegistry.register({ ptype: arc4ByteAlias, instanceEb: UintNExpressionBuilder })
+
+  // More specific types need to be registered before their base types
+  // This ensures the specific type is selected during type resolution
+  // For example, StaticBytesExpressionBuilder should be selected over general StaticArrayExpressionBuilder for StaticBytesType
+  typeRegistry.register({ ptype: DynamicBytesConstructor, singletonEb: DynamicBytesClassBuilder })
+  typeRegistry.register({ ptype: StaticBytesConstructor, singletonEb: StaticBytesClassBuilder })
+  typeRegistry.register({ ptype: DynamicBytesType, instanceEb: DynamicBytesExpressionBuilder })
+  typeRegistry.registerGeneric({ generic: StaticBytesGeneric, ptype: StaticBytesType, instanceEb: StaticBytesExpressionBuilder })
+
   typeRegistry.register({ ptype: DynamicArrayConstructor, singletonEb: DynamicArrayClassBuilder })
   typeRegistry.registerGeneric({ generic: DynamicArrayGeneric, ptype: DynamicArrayType, instanceEb: DynamicArrayExpressionBuilder })
   typeRegistry.register({ ptype: StaticArrayConstructor, singletonEb: StaticArrayClassBuilder })
@@ -381,10 +390,6 @@ export function registerPTypes(typeRegistry: TypeRegistry) {
   typeRegistry.registerGeneric({ generic: Arc4TupleGeneric, ptype: ARC4TupleType, instanceEb: Arc4TupleExpressionBuilder })
   typeRegistry.register({ ptype: ARC4StructType, instanceEb: StructExpressionBuilder })
   typeRegistry.register({ ptype: ARC4StructClass, singletonEb: StructClassBuilder })
-  typeRegistry.register({ ptype: DynamicBytesConstructor, singletonEb: DynamicBytesClassBuilder })
-  typeRegistry.register({ ptype: StaticBytesConstructor, singletonEb: StaticBytesClassBuilder })
-  typeRegistry.register({ ptype: DynamicBytesType, instanceEb: DynamicBytesExpressionBuilder })
-  typeRegistry.registerGeneric({ generic: StaticBytesGeneric, ptype: StaticBytesType, instanceEb: StaticBytesExpressionBuilder })
   typeRegistry.register({ ptype: interpretAsArc4Function, singletonEb: InterpretAsArc4FunctionBuilder })
   typeRegistry.register({ ptype: encodeArc4Function, singletonEb: EncodeArc4FunctionBuilder })
   typeRegistry.register({ ptype: decodeArc4Function, singletonEb: DecodeArc4FunctionBuilder })

--- a/tests/approvals/arc4-types.algo.ts
+++ b/tests/approvals/arc4-types.algo.ts
@@ -91,6 +91,9 @@ function testStaticBytes() {
   const s2 = new StaticBytes<4>()
   const s3 = new StaticBytes<5>(Bytes.fromHex('AABBCCDDEE'))
 
+  const s5 = new StaticArray<StaticBytes<5>, 1>(new StaticBytes<5>(Bytes.fromHex('AABBCCDDEE')))
+  assert(s5[0].native === Bytes.fromHex('AABBCCDDEE'))
+
   const s4 = s2.concat(s3)
   assert(s4.native === Bytes.fromHex('00000000AABBCCDDEE'))
 }

--- a/tests/approvals/out/o1/arc4-types/Arc4TypesTestContract.approval.teal
+++ b/tests/approvals/out/o1/arc4-types/Arc4TypesTestContract.approval.teal
@@ -3,17 +3,17 @@
 
 // tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram() -> uint64:
 main:
-    // tests/approvals/arc4-types.algo.ts:126
+    // tests/approvals/arc4-types.algo.ts:129
     // const a = new Address()
     pushbytes base32(AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA) // addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ
-    // tests/approvals/arc4-types.algo.ts:127
+    // tests/approvals/arc4-types.algo.ts:130
     // const b = new Address(Txn.sender)
     txn Sender
-    // tests/approvals/arc4-types.algo.ts:129
+    // tests/approvals/arc4-types.algo.ts:132
     // assert(a !== b, 'Zero address should not match sender')
     !=
     assert // Zero address should not match sender
-    // tests/approvals/arc4-types.algo.ts:162
+    // tests/approvals/arc4-types.algo.ts:165
     // return true
     pushint 1 // 1
     return

--- a/tests/approvals/out/o1/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.0.ssa.ir
+++ b/tests/approvals/out/o1/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.0.ssa.ir
@@ -1,5 +1,5 @@
 main tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram:
-    block@0: // L148
+    block@0: // L151
         tests/approvals/arc4-types.algo.ts::testStr()
         tests/approvals/arc4-types.algo.ts::testUintN(1u, 2b, 0x0000000000000000000000000000000000000000000000000000000000000004)
         tests/approvals/arc4-types.algo.ts::testUFixed()
@@ -124,6 +124,14 @@ subroutine tests/approvals/arc4-types.algo.ts::testDynamicBytes(someBytes: bytes
 
 subroutine tests/approvals/arc4-types.algo.ts::testStaticBytes() -> void:
     block@0: // L89
+        let result%0#0: bytes = (concat 0x 0xaabbccddee)
+        let array_data%0#0: bytes = (concat 0x result%0#0)
+        let s5#0: bytes[5] = array_data%0#0
+        let array_head_and_tail%0#0: bytes[5] = s5#0
+        let item_offset%0#0: uint64 = (* 0u 5u)
+        let tmp%0#0: bytes = (extract3 array_head_and_tail%0#0 item_offset%0#0 5u) // on error: Index access is out of bounds
+        let tmp%1#0: bool = (== tmp%0#0 0xaabbccddee)
+        (assert tmp%1#0)
         let expr_value_trimmed%0#0: bytes = ((extract 2 0) 0x000400000000)
         let concatenated%0#0: bytes = (concat expr_value_trimmed%0#0 0xaabbccddee)
         let len_%0#0: uint64 = (len concatenated%0#0)
@@ -131,13 +139,13 @@ subroutine tests/approvals/arc4-types.algo.ts::testStaticBytes() -> void:
         let len_16_bit%0#0: bytes = ((extract 6 2) as_bytes%0#0)
         let concat_result%0#0: bytes = (concat len_16_bit%0#0 concatenated%0#0)
         let s4#0: bytes = concat_result%0#0
-        let tmp%0#0: bytes = ((extract 2 0) s4#0)
-        let tmp%1#0: bool = (== tmp%0#0 0x00000000aabbccddee)
-        (assert tmp%1#0)
+        let tmp%2#0: bytes = ((extract 2 0) s4#0)
+        let tmp%3#0: bool = (== tmp%2#0 0x00000000aabbccddee)
+        (assert tmp%3#0)
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testArrays(n: bytes[8]) -> void:
-    block@0: // L101
+    block@0: // L104
         let result%0#0: bytes = (concat 0x n#0)
         let result%1#0: bytes = (concat result%0#0 n#0)
         let result%2#0: bytes = (concat result%1#0 n#0)
@@ -194,13 +202,13 @@ subroutine tests/approvals/arc4-types.algo.ts::testArrays(n: bytes[8]) -> void:
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testByte() -> void:
-    block@0: // L119
+    block@0: // L122
         let tmp%0#0: bool = (== 0x00 0x00)
         (assert tmp%0#0)
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testAddress() -> void:
-    block@0: // L125
+    block@0: // L128
         let b#0: bytes[32] = (txn Sender)
         let tmp%0#0: bool = (!= addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ b#0)
         (assert tmp%0#0) // Zero address should not match sender
@@ -214,7 +222,7 @@ subroutine tests/approvals/arc4-types.algo.ts::testAddress() -> void:
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testTuple() -> void:
-    block@0: // L134
+    block@0: // L137
         let current_tail_offset%0#0: uint64 = 8u
         let encoded_tuple_buffer%0#0: bytes[0] = 0x
         let encoded_tuple_buffer%1#0: bytes = (concat encoded_tuple_buffer%0#0 0x0000000000000022)

--- a/tests/approvals/out/o1/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.1.ssa.array.ir
+++ b/tests/approvals/out/o1/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.1.ssa.array.ir
@@ -1,5 +1,5 @@
 main tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram:
-    block@0: // L148
+    block@0: // L151
         let array%encoded%0#1: bytes[8][] = (concat 0x 0x0000000000000041)
         let array%data%0#1: bytes[8][] = (concat 0x array%encoded%0#1)
         let encoded%0#0: bytes[8][] = array%data%0#1
@@ -23,8 +23,8 @@ main tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram:
         let tmp%0#9: bytes = (itob length_minus_1#0)
         let tmp%1#8: bytes = ((extract 6 0) tmp%0#9)
         let result#1: bytes = ((replace2 0) myArray#1 tmp%1#8)
-        let tmp%2#5: uint64 = (len result#1)
-        let item_location#0: uint64 = (- tmp%2#5 8u)
+        let tmp%2#6: uint64 = (len result#1)
+        let item_location#0: uint64 = (- tmp%2#6 8u)
         let popped#0: bytes = (extract3 result#1 item_location#0 8u)
         let tmp%2#2: bool = (== 0x0000000000000041 popped#0)
         (assert tmp%2#2)

--- a/tests/approvals/out/o1/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.2.ssa.slot.ir
+++ b/tests/approvals/out/o1/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.2.ssa.slot.ir
@@ -1,5 +1,5 @@
 main tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram:
-    block@0: // L148
+    block@0: // L151
         let b#1: bytes[32] = (txn Sender)
         let tmp%0#5: bool = (!= addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ b#1)
         (assert tmp%0#5) // Zero address should not match sender

--- a/tests/approvals/out/o2/arc4-types/Arc4TypesTestContract.approval.teal
+++ b/tests/approvals/out/o2/arc4-types/Arc4TypesTestContract.approval.teal
@@ -3,17 +3,17 @@
 
 // tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram() -> uint64:
 main:
-    // tests/approvals/arc4-types.algo.ts:126
+    // tests/approvals/arc4-types.algo.ts:129
     // const a = new Address()
     pushbytes base32(AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA) // addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ
-    // tests/approvals/arc4-types.algo.ts:127
+    // tests/approvals/arc4-types.algo.ts:130
     // const b = new Address(Txn.sender)
     txn Sender
-    // tests/approvals/arc4-types.algo.ts:129
+    // tests/approvals/arc4-types.algo.ts:132
     // assert(a !== b, 'Zero address should not match sender')
     !=
     assert // Zero address should not match sender
-    // tests/approvals/arc4-types.algo.ts:162
+    // tests/approvals/arc4-types.algo.ts:165
     // return true
     pushint 1 // 1
     return

--- a/tests/approvals/out/o2/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.0.ssa.ir
+++ b/tests/approvals/out/o2/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.0.ssa.ir
@@ -1,5 +1,5 @@
 main tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram:
-    block@0: // L148
+    block@0: // L151
         tests/approvals/arc4-types.algo.ts::testStr()
         tests/approvals/arc4-types.algo.ts::testUintN(1u, 2b, 0x0000000000000000000000000000000000000000000000000000000000000004)
         tests/approvals/arc4-types.algo.ts::testUFixed()
@@ -124,6 +124,14 @@ subroutine tests/approvals/arc4-types.algo.ts::testDynamicBytes(someBytes: bytes
 
 subroutine tests/approvals/arc4-types.algo.ts::testStaticBytes() -> void:
     block@0: // L89
+        let result%0#0: bytes = (concat 0x 0xaabbccddee)
+        let array_data%0#0: bytes = (concat 0x result%0#0)
+        let s5#0: bytes[5] = array_data%0#0
+        let array_head_and_tail%0#0: bytes[5] = s5#0
+        let item_offset%0#0: uint64 = (* 0u 5u)
+        let tmp%0#0: bytes = (extract3 array_head_and_tail%0#0 item_offset%0#0 5u) // on error: Index access is out of bounds
+        let tmp%1#0: bool = (== tmp%0#0 0xaabbccddee)
+        (assert tmp%1#0)
         let expr_value_trimmed%0#0: bytes = ((extract 2 0) 0x000400000000)
         let concatenated%0#0: bytes = (concat expr_value_trimmed%0#0 0xaabbccddee)
         let len_%0#0: uint64 = (len concatenated%0#0)
@@ -131,13 +139,13 @@ subroutine tests/approvals/arc4-types.algo.ts::testStaticBytes() -> void:
         let len_16_bit%0#0: bytes = ((extract 6 2) as_bytes%0#0)
         let concat_result%0#0: bytes = (concat len_16_bit%0#0 concatenated%0#0)
         let s4#0: bytes = concat_result%0#0
-        let tmp%0#0: bytes = ((extract 2 0) s4#0)
-        let tmp%1#0: bool = (== tmp%0#0 0x00000000aabbccddee)
-        (assert tmp%1#0)
+        let tmp%2#0: bytes = ((extract 2 0) s4#0)
+        let tmp%3#0: bool = (== tmp%2#0 0x00000000aabbccddee)
+        (assert tmp%3#0)
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testArrays(n: bytes[8]) -> void:
-    block@0: // L101
+    block@0: // L104
         let result%0#0: bytes = (concat 0x n#0)
         let result%1#0: bytes = (concat result%0#0 n#0)
         let result%2#0: bytes = (concat result%1#0 n#0)
@@ -194,13 +202,13 @@ subroutine tests/approvals/arc4-types.algo.ts::testArrays(n: bytes[8]) -> void:
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testByte() -> void:
-    block@0: // L119
+    block@0: // L122
         let tmp%0#0: bool = (== 0x00 0x00)
         (assert tmp%0#0)
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testAddress() -> void:
-    block@0: // L125
+    block@0: // L128
         let b#0: bytes[32] = (txn Sender)
         let tmp%0#0: bool = (!= addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ b#0)
         (assert tmp%0#0) // Zero address should not match sender
@@ -214,7 +222,7 @@ subroutine tests/approvals/arc4-types.algo.ts::testAddress() -> void:
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testTuple() -> void:
-    block@0: // L134
+    block@0: // L137
         let current_tail_offset%0#0: uint64 = 8u
         let encoded_tuple_buffer%0#0: bytes[0] = 0x
         let encoded_tuple_buffer%1#0: bytes = (concat encoded_tuple_buffer%0#0 0x0000000000000022)

--- a/tests/approvals/out/o2/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.1.ssa.array.ir
+++ b/tests/approvals/out/o2/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.1.ssa.array.ir
@@ -1,5 +1,5 @@
 main tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram:
-    block@0: // L148
+    block@0: // L151
         let array%encoded%0#1: bytes[8][] = (concat 0x 0x0000000000000041)
         let array%data%0#1: bytes[8][] = (concat 0x array%encoded%0#1)
         let encoded%0#0: bytes[8][] = array%data%0#1
@@ -23,8 +23,8 @@ main tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram:
         let tmp%0#11: bytes = (itob length_minus_1#0)
         let tmp%1#8: bytes = ((extract 6 0) tmp%0#11)
         let result#1: bytes = ((replace2 0) myArray#1 tmp%1#8)
-        let tmp%2#5: uint64 = (len result#1)
-        let item_location#0: uint64 = (- tmp%2#5 8u)
+        let tmp%2#6: uint64 = (len result#1)
+        let item_location#0: uint64 = (- tmp%2#6 8u)
         let popped#0: bytes = (extract3 result#1 item_location#0 8u)
         let tmp%2#2: bool = (== 0x0000000000000041 popped#0)
         (assert tmp%2#2)

--- a/tests/approvals/out/o2/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.2.ssa.slot.ir
+++ b/tests/approvals/out/o2/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.2.ssa.slot.ir
@@ -1,5 +1,5 @@
 main tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram:
-    block@0: // L148
+    block@0: // L151
         let b#1: bytes[32] = (txn Sender)
         let tmp%0#6: bool = (!= addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ b#1)
         (assert tmp%0#6) // Zero address should not match sender

--- a/tests/approvals/out/unoptimized/arc4-types/Arc4TypesTestContract.approval.teal
+++ b/tests/approvals/out/unoptimized/arc4-types/Arc4TypesTestContract.approval.teal
@@ -4,57 +4,57 @@
 // tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram() -> uint64:
 main:
     intcblock 0 8 1 2
-    bytecblock 0x 0x0000 0x00 base32(AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA) 0x000548656c6c6f 0x000568656c6c6f
+    bytecblock 0x 0x0000 0x00 0xaabbccddee base32(AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA) 0x000548656c6c6f 0x000568656c6c6f
 
 main_block@0:
-    // tests/approvals/arc4-types.algo.ts:150
+    // tests/approvals/arc4-types.algo.ts:153
     // testStr()
     callsub testStr
-    // tests/approvals/arc4-types.algo.ts:151
+    // tests/approvals/arc4-types.algo.ts:154
     // testUintN(1, 2n, new UintN<256>(4))
     intc_2 // 1
     pushbytes 0x02
     pushbytes 0x0000000000000000000000000000000000000000000000000000000000000004
     callsub testUintN
-    // tests/approvals/arc4-types.algo.ts:152
+    // tests/approvals/arc4-types.algo.ts:155
     // testUFixed()
     callsub testUFixed
-    // tests/approvals/arc4-types.algo.ts:153
+    // tests/approvals/arc4-types.algo.ts:156
     // testByte()
     callsub testByte
-    // tests/approvals/arc4-types.algo.ts:154
+    // tests/approvals/arc4-types.algo.ts:157
     // testArrays(new UintN<64>(65))
     pushbytes 0x0000000000000041
     callsub testArrays
-    // tests/approvals/arc4-types.algo.ts:155
+    // tests/approvals/arc4-types.algo.ts:158
     // testAddress()
     callsub testAddress
-    // tests/approvals/arc4-types.algo.ts:156
+    // tests/approvals/arc4-types.algo.ts:159
     // testTuple()
     callsub testTuple
-    // tests/approvals/arc4-types.algo.ts:157
+    // tests/approvals/arc4-types.algo.ts:160
     // testUFixed()
     callsub testUFixed
-    // tests/approvals/arc4-types.algo.ts:158
+    // tests/approvals/arc4-types.algo.ts:161
     // testDynamicBytes(Bytes('hmmmmmmmmm'))
     pushbytes "hmmmmmmmmm"
     callsub testDynamicBytes
-    // tests/approvals/arc4-types.algo.ts:159
+    // tests/approvals/arc4-types.algo.ts:162
     // testStaticBytes()
     callsub testStaticBytes
-    // tests/approvals/arc4-types.algo.ts:160
+    // tests/approvals/arc4-types.algo.ts:163
     // const result = new arc4.DynamicArray<arc4.UintN<64>>()
     bytec_1 // 0x0000
     bytec_0 // 0x
     concat
-    // tests/approvals/arc4-types.algo.ts:161
+    // tests/approvals/arc4-types.algo.ts:164
     // assert(result.length === 0)
     intc_0 // 0
     extract_uint16
     intc_0 // 0
     ==
     assert
-    // tests/approvals/arc4-types.algo.ts:162
+    // tests/approvals/arc4-types.algo.ts:165
     // return true
     intc_2 // 1
     return
@@ -229,7 +229,7 @@ testStr_block@0:
     assert // Empty string should equal the uint16 length prefix
     // tests/approvals/arc4-types.algo.ts:65
     // const s2 = new Str('Hello')
-    bytec 4 // 0x000548656c6c6f
+    bytec 5 // 0x000548656c6c6f
     // tests/approvals/arc4-types.algo.ts:66
     // assert(s2.native === 'Hello')
     extract 2 0
@@ -238,7 +238,7 @@ testStr_block@0:
     assert
     // tests/approvals/arc4-types.algo.ts:65
     // const s2 = new Str('Hello')
-    bytec 4 // 0x000548656c6c6f
+    bytec 5 // 0x000548656c6c6f
     dup
     // tests/approvals/arc4-types.algo.ts:72
     // assert(s2 === s2_from_bytes)
@@ -285,7 +285,7 @@ testDynamicBytes_block@0:
     assert
     // tests/approvals/arc4-types.algo.ts:82
     // const db3 = new DynamicBytes('hello')
-    bytec 5 // 0x000568656c6c6f
+    bytec 6 // 0x000568656c6c6f
     // tests/approvals/arc4-types.algo.ts:83
     // assert(db3.native === Bytes('hello'))
     extract 2 0
@@ -294,7 +294,7 @@ testDynamicBytes_block@0:
     assert
     // tests/approvals/arc4-types.algo.ts:82
     // const db3 = new DynamicBytes('hello')
-    bytec 5 // 0x000568656c6c6f
+    bytec 6 // 0x000568656c6c6f
     // tests/approvals/arc4-types.algo.ts:85
     // const db4 = db3.concat(new DynamicBytes(' world'))
     extract 2 0
@@ -320,16 +320,34 @@ testDynamicBytes_block@0:
 testStaticBytes:
 
 testStaticBytes_block@0:
+    // tests/approvals/arc4-types.algo.ts:94
+    // const s5 = new StaticArray<StaticBytes<5>, 1>(new StaticBytes<5>(Bytes.fromHex('AABBCCDDEE')))
+    bytec_0 // 0x
+    bytec_3 // 0xaabbccddee
+    concat
+    bytec_0 // 0x
+    swap
+    concat
+    // tests/approvals/arc4-types.algo.ts:95
+    // assert(s5[0].native === Bytes.fromHex('AABBCCDDEE'))
+    intc_0 // 0
+    pushint 5 // 5
+    *
+    pushint 5 // 5
+    extract3 // on error: Index access is out of bounds
+    bytec_3 // 0xaabbccddee
+    ==
+    assert
     // tests/approvals/arc4-types.algo.ts:91
     // const s2 = new StaticBytes<4>()
     pushbytes 0x000400000000
-    // tests/approvals/arc4-types.algo.ts:94
+    // tests/approvals/arc4-types.algo.ts:97
     // const s4 = s2.concat(s3)
     extract 2 0
     // tests/approvals/arc4-types.algo.ts:92
     // const s3 = new StaticBytes<5>(Bytes.fromHex('AABBCCDDEE'))
-    pushbytes 0xaabbccddee
-    // tests/approvals/arc4-types.algo.ts:94
+    bytec_3 // 0xaabbccddee
+    // tests/approvals/arc4-types.algo.ts:97
     // const s4 = s2.concat(s3)
     concat
     dup
@@ -338,7 +356,7 @@ testStaticBytes_block@0:
     extract 6 2
     swap
     concat
-    // tests/approvals/arc4-types.algo.ts:95
+    // tests/approvals/arc4-types.algo.ts:98
     // assert(s4.native === Bytes.fromHex('00000000AABBCCDDEE'))
     extract 2 0
     pushbytes 0x00000000aabbccddee
@@ -349,12 +367,12 @@ testStaticBytes_block@0:
 
 // tests/approvals/arc4-types.algo.ts::testArrays(n: bytes) -> void:
 testArrays:
-    // tests/approvals/arc4-types.algo.ts:101
+    // tests/approvals/arc4-types.algo.ts:104
     // function testArrays(n: ARC4Uint64) {
     proto 1 0
 
 testArrays_block@0:
-    // tests/approvals/arc4-types.algo.ts:102
+    // tests/approvals/arc4-types.algo.ts:105
     // const myArray = new DynamicArray(n, n, n)
     bytec_0 // 0x
     frame_dig -1
@@ -366,7 +384,7 @@ testArrays_block@0:
     pushbytes 0x0003
     swap
     concat
-    // tests/approvals/arc4-types.algo.ts:104
+    // tests/approvals/arc4-types.algo.ts:107
     // myArray.push(n)
     extract 2 0
     bytec_0 // 0x
@@ -384,7 +402,7 @@ testArrays_block@0:
     extract 6 2
     swap
     concat
-    // tests/approvals/arc4-types.algo.ts:106
+    // tests/approvals/arc4-types.algo.ts:109
     // const doubleArray = myArray.concat(myArray)
     dup
     extract 2 0
@@ -402,7 +420,7 @@ testArrays_block@0:
     extract 6 2
     swap
     concat
-    // tests/approvals/arc4-types.algo.ts:108
+    // tests/approvals/arc4-types.algo.ts:111
     // assert(doubleArray === new DynamicArray(n, n, n, n, n, n, n, n))
     bytec_0 // 0x
     frame_dig -1
@@ -426,7 +444,7 @@ testArrays_block@0:
     concat
     ==
     assert
-    // tests/approvals/arc4-types.algo.ts:110
+    // tests/approvals/arc4-types.algo.ts:113
     // const myStatic = new StaticArray(n, n)
     bytec_0 // 0x
     frame_dig -1
@@ -436,7 +454,7 @@ testArrays_block@0:
     bytec_0 // 0x
     swap
     concat
-    // tests/approvals/arc4-types.algo.ts:112
+    // tests/approvals/arc4-types.algo.ts:115
     // assert(myStatic[0] === myArray.pop())
     intc_0 // 0
     intc_1 // 8
@@ -456,13 +474,13 @@ testArrays_block@0:
 testByte:
 
 testByte_block@0:
-    // tests/approvals/arc4-types.algo.ts:120
+    // tests/approvals/arc4-types.algo.ts:123
     // const b = new Byte()
     bytec_2 // 0x00
-    // tests/approvals/arc4-types.algo.ts:121
+    // tests/approvals/arc4-types.algo.ts:124
     // const b2 = new Byte(0)
     dup
-    // tests/approvals/arc4-types.algo.ts:122
+    // tests/approvals/arc4-types.algo.ts:125
     // assert(b === b2)
     ==
     assert
@@ -473,33 +491,33 @@ testByte_block@0:
 testAddress:
 
 testAddress_block@0:
-    // tests/approvals/arc4-types.algo.ts:127
+    // tests/approvals/arc4-types.algo.ts:130
     // const b = new Address(Txn.sender)
     txn Sender
-    // tests/approvals/arc4-types.algo.ts:126
-    // const a = new Address()
-    bytec_3 // addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ
     // tests/approvals/arc4-types.algo.ts:129
+    // const a = new Address()
+    bytec 4 // addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ
+    // tests/approvals/arc4-types.algo.ts:132
     // assert(a !== b, 'Zero address should not match sender')
     !=
     assert // Zero address should not match sender
-    // tests/approvals/arc4-types.algo.ts:126
+    // tests/approvals/arc4-types.algo.ts:129
     // const a = new Address()
-    bytec_3 // addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ
-    // tests/approvals/arc4-types.algo.ts:130
+    bytec 4 // addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ
+    // tests/approvals/arc4-types.algo.ts:133
     // assert(a === new Address(), 'Two zero addresses should match')
     dup
     ==
     assert // Two zero addresses should match
-    // tests/approvals/arc4-types.algo.ts:131
+    // tests/approvals/arc4-types.algo.ts:134
     // assert(a[0] === new Byte(), 'Zero address should start with zero byte')
     intc_0 // 0
     intc_2 // 1
     *
-    // tests/approvals/arc4-types.algo.ts:126
+    // tests/approvals/arc4-types.algo.ts:129
     // const a = new Address()
-    bytec_3 // addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ
-    // tests/approvals/arc4-types.algo.ts:131
+    bytec 4 // addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ
+    // tests/approvals/arc4-types.algo.ts:134
     // assert(a[0] === new Byte(), 'Zero address should start with zero byte')
     swap
     intc_2 // 1
@@ -514,28 +532,28 @@ testAddress_block@0:
 testTuple:
 
 testTuple_block@0:
-    // tests/approvals/arc4-types.algo.ts:135
+    // tests/approvals/arc4-types.algo.ts:138
     // const t = new Tuple(new ARC4Uint64(34))
     bytec_0 // 0x
     pushbytes 0x0000000000000022
     concat
-    // tests/approvals/arc4-types.algo.ts:136
+    // tests/approvals/arc4-types.algo.ts:139
     // const firstItem = t.at(0)
     dup
     intc_0 // 0
     intc_1 // 8
     extract3 // on error: Index access is out of bounds
     swap
-    // tests/approvals/arc4-types.algo.ts:137
+    // tests/approvals/arc4-types.algo.ts:140
     // const firstItemIndexer = t.native[0]
     intc_0 // 0
     intc_1 // 8
     extract3 // on error: Index access is out of bounds
-    // tests/approvals/arc4-types.algo.ts:138
+    // tests/approvals/arc4-types.algo.ts:141
     // assert(firstItem === firstItemIndexer)
     ==
     assert
-    // tests/approvals/arc4-types.algo.ts:140
+    // tests/approvals/arc4-types.algo.ts:143
     // assert(t1.length === 2)
     intc_3 // 2
     dup

--- a/tests/approvals/out/unoptimized/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.0.ssa.ir
+++ b/tests/approvals/out/unoptimized/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.0.ssa.ir
@@ -1,5 +1,5 @@
 main tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram:
-    block@0: // L148
+    block@0: // L151
         tests/approvals/arc4-types.algo.ts::testStr()
         tests/approvals/arc4-types.algo.ts::testUintN(1u, 2b, 0x0000000000000000000000000000000000000000000000000000000000000004)
         tests/approvals/arc4-types.algo.ts::testUFixed()
@@ -124,6 +124,14 @@ subroutine tests/approvals/arc4-types.algo.ts::testDynamicBytes(someBytes: bytes
 
 subroutine tests/approvals/arc4-types.algo.ts::testStaticBytes() -> void:
     block@0: // L89
+        let result%0#0: bytes = (concat 0x 0xaabbccddee)
+        let array_data%0#0: bytes = (concat 0x result%0#0)
+        let s5#0: bytes[5] = array_data%0#0
+        let array_head_and_tail%0#0: bytes[5] = s5#0
+        let item_offset%0#0: uint64 = (* 0u 5u)
+        let tmp%0#0: bytes = (extract3 array_head_and_tail%0#0 item_offset%0#0 5u) // on error: Index access is out of bounds
+        let tmp%1#0: bool = (== tmp%0#0 0xaabbccddee)
+        (assert tmp%1#0)
         let expr_value_trimmed%0#0: bytes = ((extract 2 0) 0x000400000000)
         let concatenated%0#0: bytes = (concat expr_value_trimmed%0#0 0xaabbccddee)
         let len_%0#0: uint64 = (len concatenated%0#0)
@@ -131,13 +139,13 @@ subroutine tests/approvals/arc4-types.algo.ts::testStaticBytes() -> void:
         let len_16_bit%0#0: bytes = ((extract 6 2) as_bytes%0#0)
         let concat_result%0#0: bytes = (concat len_16_bit%0#0 concatenated%0#0)
         let s4#0: bytes = concat_result%0#0
-        let tmp%0#0: bytes = ((extract 2 0) s4#0)
-        let tmp%1#0: bool = (== tmp%0#0 0x00000000aabbccddee)
-        (assert tmp%1#0)
+        let tmp%2#0: bytes = ((extract 2 0) s4#0)
+        let tmp%3#0: bool = (== tmp%2#0 0x00000000aabbccddee)
+        (assert tmp%3#0)
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testArrays(n: bytes[8]) -> void:
-    block@0: // L101
+    block@0: // L104
         let result%0#0: bytes = (concat 0x n#0)
         let result%1#0: bytes = (concat result%0#0 n#0)
         let result%2#0: bytes = (concat result%1#0 n#0)
@@ -194,13 +202,13 @@ subroutine tests/approvals/arc4-types.algo.ts::testArrays(n: bytes[8]) -> void:
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testByte() -> void:
-    block@0: // L119
+    block@0: // L122
         let tmp%0#0: bool = (== 0x00 0x00)
         (assert tmp%0#0)
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testAddress() -> void:
-    block@0: // L125
+    block@0: // L128
         let b#0: bytes[32] = (txn Sender)
         let tmp%0#0: bool = (!= addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ b#0)
         (assert tmp%0#0) // Zero address should not match sender
@@ -214,7 +222,7 @@ subroutine tests/approvals/arc4-types.algo.ts::testAddress() -> void:
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testTuple() -> void:
-    block@0: // L134
+    block@0: // L137
         let current_tail_offset%0#0: uint64 = 8u
         let encoded_tuple_buffer%0#0: bytes[0] = 0x
         let encoded_tuple_buffer%1#0: bytes = (concat encoded_tuple_buffer%0#0 0x0000000000000022)

--- a/tests/approvals/out/unoptimized/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.1.ssa.array.ir
+++ b/tests/approvals/out/unoptimized/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.1.ssa.array.ir
@@ -1,5 +1,5 @@
 main tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram:
-    block@0: // L148
+    block@0: // L151
         tests/approvals/arc4-types.algo.ts::testStr()
         tests/approvals/arc4-types.algo.ts::testUintN(1u, 2b, 0x0000000000000000000000000000000000000000000000000000000000000004)
         tests/approvals/arc4-types.algo.ts::testUFixed()
@@ -121,6 +121,14 @@ subroutine tests/approvals/arc4-types.algo.ts::testDynamicBytes(someBytes: bytes
 
 subroutine tests/approvals/arc4-types.algo.ts::testStaticBytes() -> void:
     block@0: // L89
+        let result%0#0: bytes = (concat 0x 0xaabbccddee)
+        let array_data%0#0: bytes = (concat 0x result%0#0)
+        let s5#0: bytes[5] = array_data%0#0
+        let array_head_and_tail%0#0: bytes[5] = s5#0
+        let item_offset%0#0: uint64 = (* 0u 5u)
+        let tmp%0#0: bytes = (extract3 array_head_and_tail%0#0 item_offset%0#0 5u) // on error: Index access is out of bounds
+        let tmp%1#0: bool = (== tmp%0#0 0xaabbccddee)
+        (assert tmp%1#0)
         let expr_value_trimmed%0#0: bytes = ((extract 2 0) 0x000400000000)
         let concatenated%0#0: bytes = (concat expr_value_trimmed%0#0 0xaabbccddee)
         let len_%0#0: uint64 = (len concatenated%0#0)
@@ -128,13 +136,13 @@ subroutine tests/approvals/arc4-types.algo.ts::testStaticBytes() -> void:
         let len_16_bit%0#0: bytes = ((extract 6 2) as_bytes%0#0)
         let concat_result%0#0: bytes = (concat len_16_bit%0#0 concatenated%0#0)
         let s4#0: bytes = concat_result%0#0
-        let tmp%0#0: bytes = ((extract 2 0) s4#0)
-        let tmp%1#0: bool = (== tmp%0#0 0x00000000aabbccddee)
-        (assert tmp%1#0)
+        let tmp%2#0: bytes = ((extract 2 0) s4#0)
+        let tmp%3#0: bool = (== tmp%2#0 0x00000000aabbccddee)
+        (assert tmp%3#0)
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testArrays(n: bytes[8]) -> void:
-    block@0: // L101
+    block@0: // L104
         let result%0#0: bytes = (concat 0x n#0)
         let result%1#0: bytes = (concat result%0#0 n#0)
         let result%2#0: bytes = (concat result%1#0 n#0)
@@ -184,13 +192,13 @@ subroutine tests/approvals/arc4-types.algo.ts::testArrays(n: bytes[8]) -> void:
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testByte() -> void:
-    block@0: // L119
+    block@0: // L122
         let tmp%0#0: bool = (== 0x00 0x00)
         (assert tmp%0#0)
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testAddress() -> void:
-    block@0: // L125
+    block@0: // L128
         let b#0: bytes[32] = (txn Sender)
         let tmp%0#0: bool = (!= addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ b#0)
         (assert tmp%0#0) // Zero address should not match sender
@@ -203,7 +211,7 @@ subroutine tests/approvals/arc4-types.algo.ts::testAddress() -> void:
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testTuple() -> void:
-    block@0: // L134
+    block@0: // L137
         let encoded_tuple_buffer%1#0: bytes = (concat 0x 0x0000000000000022)
         let t#0: bytes[8] = encoded_tuple_buffer%1#0
         let firstItem#0: bytes[8] = (extract3 t#0 0u 8u) // on error: Index access is out of bounds

--- a/tests/approvals/out/unoptimized/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.2.ssa.slot.ir
+++ b/tests/approvals/out/unoptimized/arc4-types/Arc4TypesTestContract.ir/Arc4TypesTestContract.approval.2.ssa.slot.ir
@@ -1,5 +1,5 @@
 main tests/approvals/arc4-types.algo.ts::Arc4TypesTestContract.approvalProgram:
-    block@0: // L148
+    block@0: // L151
         tests/approvals/arc4-types.algo.ts::testStr()
         tests/approvals/arc4-types.algo.ts::testUintN(1u, 2b, 0x0000000000000000000000000000000000000000000000000000000000000004)
         tests/approvals/arc4-types.algo.ts::testUFixed()
@@ -121,6 +121,14 @@ subroutine tests/approvals/arc4-types.algo.ts::testDynamicBytes(someBytes: bytes
 
 subroutine tests/approvals/arc4-types.algo.ts::testStaticBytes() -> void:
     block@0: // L89
+        let result%0#0: bytes = (concat 0x 0xaabbccddee)
+        let array_data%0#0: bytes = (concat 0x result%0#0)
+        let s5#0: bytes[5] = array_data%0#0
+        let array_head_and_tail%0#0: bytes[5] = s5#0
+        let item_offset%0#0: uint64 = (* 0u 5u)
+        let tmp%0#0: bytes = (extract3 array_head_and_tail%0#0 item_offset%0#0 5u) // on error: Index access is out of bounds
+        let tmp%1#0: bool = (== tmp%0#0 0xaabbccddee)
+        (assert tmp%1#0)
         let expr_value_trimmed%0#0: bytes = ((extract 2 0) 0x000400000000)
         let concatenated%0#0: bytes = (concat expr_value_trimmed%0#0 0xaabbccddee)
         let len_%0#0: uint64 = (len concatenated%0#0)
@@ -128,13 +136,13 @@ subroutine tests/approvals/arc4-types.algo.ts::testStaticBytes() -> void:
         let len_16_bit%0#0: bytes = ((extract 6 2) as_bytes%0#0)
         let concat_result%0#0: bytes = (concat len_16_bit%0#0 concatenated%0#0)
         let s4#0: bytes = concat_result%0#0
-        let tmp%0#0: bytes = ((extract 2 0) s4#0)
-        let tmp%1#0: bool = (== tmp%0#0 0x00000000aabbccddee)
-        (assert tmp%1#0)
+        let tmp%2#0: bytes = ((extract 2 0) s4#0)
+        let tmp%3#0: bool = (== tmp%2#0 0x00000000aabbccddee)
+        (assert tmp%3#0)
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testArrays(n: bytes[8]) -> void:
-    block@0: // L101
+    block@0: // L104
         let result%0#0: bytes = (concat 0x n#0)
         let result%1#0: bytes = (concat result%0#0 n#0)
         let result%2#0: bytes = (concat result%1#0 n#0)
@@ -184,13 +192,13 @@ subroutine tests/approvals/arc4-types.algo.ts::testArrays(n: bytes[8]) -> void:
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testByte() -> void:
-    block@0: // L119
+    block@0: // L122
         let tmp%0#0: bool = (== 0x00 0x00)
         (assert tmp%0#0)
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testAddress() -> void:
-    block@0: // L125
+    block@0: // L128
         let b#0: bytes[32] = (txn Sender)
         let tmp%0#0: bool = (!= addr AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ b#0)
         (assert tmp%0#0) // Zero address should not match sender
@@ -203,7 +211,7 @@ subroutine tests/approvals/arc4-types.algo.ts::testAddress() -> void:
         return 
 
 subroutine tests/approvals/arc4-types.algo.ts::testTuple() -> void:
-    block@0: // L134
+    block@0: // L137
         let encoded_tuple_buffer%1#0: bytes = (concat 0x 0x0000000000000022)
         let t#0: bytes[8] = encoded_tuple_buffer%1#0
         let firstItem#0: bytes[8] = (extract3 t#0 0u 8u) // on error: Index access is out of bounds

--- a/tests/approvals/out/unoptimized/arc4-types/arc4-types.awst
+++ b/tests/approvals/out/unoptimized/arc4-types/arc4-types.awst
@@ -41,6 +41,8 @@ subroutine testDynamicBytes(someBytes: bytes): void
 }
 subroutine testStaticBytes(): void
 {
+  s5: arc4.static_array<arc4.static_array<arc4.byte>> = new arc4.static_array<arc4.static_array<arc4.byte>>(0xaabbccddee)
+  assert(reinterpret_cast<bytes>(s5[0]) == 0xaabbccddee)
   s4: arc4.dynamic_array<arc4.byte> = 0x000400000000.concat(0xaabbccddee)
   assert(ARC4_DECODE(s4) == 0x00000000aabbccddee)
 }

--- a/tests/approvals/out/unoptimized/arc4-types/arc4-types.awst.json
+++ b/tests/approvals/out/unoptimized/arc4-types/arc4-types.awst.json
@@ -3577,7 +3577,7 @@
       "source_location": {
         "file": "tests/approvals/arc4-types.algo.ts",
         "line": 89,
-        "end_line": 96,
+        "end_line": 99,
         "column": 27,
         "end_column": 1
       },
@@ -3589,7 +3589,7 @@
             "line": 94,
             "end_line": 94,
             "column": 8,
-            "end_column": 26
+            "end_column": 96
           },
           "target": {
             "_type": "VarExpression",
@@ -3597,6 +3597,371 @@
               "file": "tests/approvals/arc4-types.algo.ts",
               "line": 94,
               "end_line": 94,
+              "column": 8,
+              "end_column": 10
+            },
+            "wtype": {
+              "_type": "ARC4StaticArray",
+              "name": "arc4.static_array<arc4.static_array<arc4.byte>>",
+              "immutable": false,
+              "ephemeral": false,
+              "scalar_type": 1,
+              "native_type": null,
+              "arc4_name": "byte[5][1]",
+              "element_type": {
+                "_type": "ARC4StaticArray",
+                "name": "arc4.static_array<arc4.byte>",
+                "immutable": true,
+                "ephemeral": false,
+                "scalar_type": 1,
+                "native_type": {
+                  "_type": "WType",
+                  "name": "bytes",
+                  "immutable": true,
+                  "ephemeral": false,
+                  "scalar_type": 1
+                },
+                "arc4_name": "byte[5]",
+                "element_type": {
+                  "_type": "ARC4UIntN",
+                  "name": "arc4.byte",
+                  "immutable": true,
+                  "ephemeral": false,
+                  "scalar_type": 1,
+                  "native_type": {
+                    "_type": "WType",
+                    "name": "uint64",
+                    "immutable": true,
+                    "ephemeral": false,
+                    "scalar_type": 2
+                  },
+                  "arc4_name": "byte",
+                  "n": 8
+                },
+                "source_location": null,
+                "array_size": 5
+              },
+              "source_location": null,
+              "array_size": 1
+            },
+            "name": "s5"
+          },
+          "value": {
+            "_type": "NewArray",
+            "source_location": {
+              "file": "tests/approvals/arc4-types.algo.ts",
+              "line": 94,
+              "end_line": 94,
+              "column": 13,
+              "end_column": 96
+            },
+            "wtype": {
+              "_type": "ARC4StaticArray",
+              "name": "arc4.static_array<arc4.static_array<arc4.byte>>",
+              "immutable": false,
+              "ephemeral": false,
+              "scalar_type": 1,
+              "native_type": null,
+              "arc4_name": "byte[5][1]",
+              "element_type": {
+                "_type": "ARC4StaticArray",
+                "name": "arc4.static_array<arc4.byte>",
+                "immutable": true,
+                "ephemeral": false,
+                "scalar_type": 1,
+                "native_type": {
+                  "_type": "WType",
+                  "name": "bytes",
+                  "immutable": true,
+                  "ephemeral": false,
+                  "scalar_type": 1
+                },
+                "arc4_name": "byte[5]",
+                "element_type": {
+                  "_type": "ARC4UIntN",
+                  "name": "arc4.byte",
+                  "immutable": true,
+                  "ephemeral": false,
+                  "scalar_type": 1,
+                  "native_type": {
+                    "_type": "WType",
+                    "name": "uint64",
+                    "immutable": true,
+                    "ephemeral": false,
+                    "scalar_type": 2
+                  },
+                  "arc4_name": "byte",
+                  "n": 8
+                },
+                "source_location": null,
+                "array_size": 5
+              },
+              "source_location": null,
+              "array_size": 1
+            },
+            "values": [
+              {
+                "_type": "BytesConstant",
+                "source_location": {
+                  "file": "tests/approvals/arc4-types.algo.ts",
+                  "line": 94,
+                  "end_line": 94,
+                  "column": 48,
+                  "end_column": 95
+                },
+                "wtype": {
+                  "_type": "ARC4StaticArray",
+                  "name": "arc4.static_array<arc4.byte>",
+                  "immutable": true,
+                  "ephemeral": false,
+                  "scalar_type": 1,
+                  "native_type": {
+                    "_type": "WType",
+                    "name": "bytes",
+                    "immutable": true,
+                    "ephemeral": false,
+                    "scalar_type": 1
+                  },
+                  "arc4_name": "byte[5]",
+                  "element_type": {
+                    "_type": "ARC4UIntN",
+                    "name": "arc4.byte",
+                    "immutable": true,
+                    "ephemeral": false,
+                    "scalar_type": 1,
+                    "native_type": {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true,
+                      "ephemeral": false,
+                      "scalar_type": 2
+                    },
+                    "arc4_name": "byte",
+                    "n": 8
+                  },
+                  "source_location": null,
+                  "array_size": 5
+                },
+                "value": "s=LhH?f",
+                "encoding": "unknown"
+              }
+            ]
+          }
+        },
+        {
+          "_type": "ExpressionStatement",
+          "source_location": {
+            "file": "tests/approvals/arc4-types.algo.ts",
+            "line": 95,
+            "end_line": 95,
+            "column": 2,
+            "end_column": 54
+          },
+          "expr": {
+            "_type": "AssertExpression",
+            "source_location": {
+              "file": "tests/approvals/arc4-types.algo.ts",
+              "line": 95,
+              "end_line": 95,
+              "column": 2,
+              "end_column": 54
+            },
+            "wtype": {
+              "_type": "WType",
+              "name": "void",
+              "immutable": true,
+              "ephemeral": false,
+              "scalar_type": null
+            },
+            "condition": {
+              "_type": "BytesComparisonExpression",
+              "source_location": {
+                "file": "tests/approvals/arc4-types.algo.ts",
+                "line": 95,
+                "end_line": 95,
+                "column": 9,
+                "end_column": 53
+              },
+              "wtype": {
+                "_type": "WType",
+                "name": "bool",
+                "immutable": true,
+                "ephemeral": false,
+                "scalar_type": 2
+              },
+              "lhs": {
+                "_type": "ReinterpretCast",
+                "source_location": {
+                  "file": "tests/approvals/arc4-types.algo.ts",
+                  "line": 95,
+                  "end_line": 95,
+                  "column": 15,
+                  "end_column": 21
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "bytes",
+                  "immutable": true,
+                  "ephemeral": false,
+                  "scalar_type": 1
+                },
+                "expr": {
+                  "_type": "IndexExpression",
+                  "source_location": {
+                    "file": "tests/approvals/arc4-types.algo.ts",
+                    "line": 95,
+                    "end_line": 95,
+                    "column": 9,
+                    "end_column": 14
+                  },
+                  "wtype": {
+                    "_type": "ARC4StaticArray",
+                    "name": "arc4.static_array<arc4.byte>",
+                    "immutable": true,
+                    "ephemeral": false,
+                    "scalar_type": 1,
+                    "native_type": {
+                      "_type": "WType",
+                      "name": "bytes",
+                      "immutable": true,
+                      "ephemeral": false,
+                      "scalar_type": 1
+                    },
+                    "arc4_name": "byte[5]",
+                    "element_type": {
+                      "_type": "ARC4UIntN",
+                      "name": "arc4.byte",
+                      "immutable": true,
+                      "ephemeral": false,
+                      "scalar_type": 1,
+                      "native_type": {
+                        "_type": "WType",
+                        "name": "uint64",
+                        "immutable": true,
+                        "ephemeral": false,
+                        "scalar_type": 2
+                      },
+                      "arc4_name": "byte",
+                      "n": 8
+                    },
+                    "source_location": null,
+                    "array_size": 5
+                  },
+                  "base": {
+                    "_type": "VarExpression",
+                    "source_location": {
+                      "file": "tests/approvals/arc4-types.algo.ts",
+                      "line": 95,
+                      "end_line": 95,
+                      "column": 9,
+                      "end_column": 11
+                    },
+                    "wtype": {
+                      "_type": "ARC4StaticArray",
+                      "name": "arc4.static_array<arc4.static_array<arc4.byte>>",
+                      "immutable": false,
+                      "ephemeral": false,
+                      "scalar_type": 1,
+                      "native_type": null,
+                      "arc4_name": "byte[5][1]",
+                      "element_type": {
+                        "_type": "ARC4StaticArray",
+                        "name": "arc4.static_array<arc4.byte>",
+                        "immutable": true,
+                        "ephemeral": false,
+                        "scalar_type": 1,
+                        "native_type": {
+                          "_type": "WType",
+                          "name": "bytes",
+                          "immutable": true,
+                          "ephemeral": false,
+                          "scalar_type": 1
+                        },
+                        "arc4_name": "byte[5]",
+                        "element_type": {
+                          "_type": "ARC4UIntN",
+                          "name": "arc4.byte",
+                          "immutable": true,
+                          "ephemeral": false,
+                          "scalar_type": 1,
+                          "native_type": {
+                            "_type": "WType",
+                            "name": "uint64",
+                            "immutable": true,
+                            "ephemeral": false,
+                            "scalar_type": 2
+                          },
+                          "arc4_name": "byte",
+                          "n": 8
+                        },
+                        "source_location": null,
+                        "array_size": 5
+                      },
+                      "source_location": null,
+                      "array_size": 1
+                    },
+                    "name": "s5"
+                  },
+                  "index": {
+                    "_type": "IntegerConstant",
+                    "source_location": {
+                      "file": "tests/approvals/arc4-types.algo.ts",
+                      "line": 95,
+                      "end_line": 95,
+                      "column": 12,
+                      "end_column": 13
+                    },
+                    "wtype": {
+                      "_type": "WType",
+                      "name": "uint64",
+                      "immutable": true,
+                      "ephemeral": false,
+                      "scalar_type": 2
+                    },
+                    "value": 0,
+                    "teal_alias": null
+                  }
+                }
+              },
+              "operator": "==",
+              "rhs": {
+                "_type": "BytesConstant",
+                "source_location": {
+                  "file": "tests/approvals/arc4-types.algo.ts",
+                  "line": 95,
+                  "end_line": 95,
+                  "column": 26,
+                  "end_column": 53
+                },
+                "wtype": {
+                  "_type": "WType",
+                  "name": "bytes",
+                  "immutable": true,
+                  "ephemeral": false,
+                  "scalar_type": 1
+                },
+                "value": "s=LhH?f",
+                "encoding": "base16"
+              }
+            },
+            "error_message": null
+          }
+        },
+        {
+          "_type": "AssignmentStatement",
+          "source_location": {
+            "file": "tests/approvals/arc4-types.algo.ts",
+            "line": 97,
+            "end_line": 97,
+            "column": 8,
+            "end_column": 26
+          },
+          "target": {
+            "_type": "VarExpression",
+            "source_location": {
+              "file": "tests/approvals/arc4-types.algo.ts",
+              "line": 97,
+              "end_line": 97,
               "column": 8,
               "end_column": 10
             },
@@ -3638,8 +4003,8 @@
             "_type": "ArrayConcat",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 94,
-              "end_line": 94,
+              "line": 97,
+              "end_line": 97,
               "column": 13,
               "end_column": 26
             },
@@ -3770,8 +4135,8 @@
           "_type": "ExpressionStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 95,
-            "end_line": 95,
+            "line": 98,
+            "end_line": 98,
             "column": 2,
             "end_column": 59
           },
@@ -3779,8 +4144,8 @@
             "_type": "AssertExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 95,
-              "end_line": 95,
+              "line": 98,
+              "end_line": 98,
               "column": 2,
               "end_column": 59
             },
@@ -3795,8 +4160,8 @@
               "_type": "BytesComparisonExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 95,
-                "end_line": 95,
+                "line": 98,
+                "end_line": 98,
                 "column": 9,
                 "end_column": 58
               },
@@ -3811,8 +4176,8 @@
                 "_type": "ARC4Decode",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 95,
-                  "end_line": 95,
+                  "line": 98,
+                  "end_line": 98,
                   "column": 12,
                   "end_column": 18
                 },
@@ -3827,8 +4192,8 @@
                   "_type": "VarExpression",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 95,
-                    "end_line": 95,
+                    "line": 98,
+                    "end_line": 98,
                     "column": 9,
                     "end_column": 11
                   },
@@ -3872,8 +4237,8 @@
                 "_type": "BytesConstant",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 95,
-                  "end_line": 95,
+                  "line": 98,
+                  "end_line": 98,
                   "column": 23,
                   "end_column": 58
                 },
@@ -3909,8 +4274,8 @@
     "_type": "Subroutine",
     "source_location": {
       "file": "tests/approvals/arc4-types.algo.ts",
-      "line": 101,
-      "end_line": 101,
+      "line": 104,
+      "end_line": 104,
       "column": 0,
       "end_column": 34
     },
@@ -3920,8 +4285,8 @@
         "name": "n",
         "source_location": {
           "file": "tests/approvals/arc4-types.algo.ts",
-          "line": 101,
-          "end_line": 101,
+          "line": 104,
+          "end_line": 104,
           "column": 20,
           "end_column": 33
         },
@@ -3954,8 +4319,8 @@
       "_type": "Block",
       "source_location": {
         "file": "tests/approvals/arc4-types.algo.ts",
-        "line": 101,
-        "end_line": 117,
+        "line": 104,
+        "end_line": 120,
         "column": 35,
         "end_column": 1
       },
@@ -3964,8 +4329,8 @@
           "_type": "AssignmentStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 102,
-            "end_line": 102,
+            "line": 105,
+            "end_line": 105,
             "column": 8,
             "end_column": 43
           },
@@ -3973,8 +4338,8 @@
             "_type": "VarExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 102,
-              "end_line": 102,
+              "line": 105,
+              "end_line": 105,
               "column": 8,
               "end_column": 15
             },
@@ -4010,8 +4375,8 @@
             "_type": "NewArray",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 102,
-              "end_line": 102,
+              "line": 105,
+              "end_line": 105,
               "column": 18,
               "end_column": 43
             },
@@ -4041,8 +4406,8 @@
               },
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 102,
-                "end_line": 102,
+                "line": 105,
+                "end_line": 105,
                 "column": 18,
                 "end_column": 43
               }
@@ -4052,8 +4417,8 @@
                 "_type": "VarExpression",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 102,
-                  "end_line": 102,
+                  "line": 105,
+                  "end_line": 105,
                   "column": 35,
                   "end_column": 36
                 },
@@ -4079,8 +4444,8 @@
                 "_type": "VarExpression",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 102,
-                  "end_line": 102,
+                  "line": 105,
+                  "end_line": 105,
                   "column": 38,
                   "end_column": 39
                 },
@@ -4106,8 +4471,8 @@
                 "_type": "VarExpression",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 102,
-                  "end_line": 102,
+                  "line": 105,
+                  "end_line": 105,
                   "column": 41,
                   "end_column": 42
                 },
@@ -4136,8 +4501,8 @@
           "_type": "ExpressionStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 104,
-            "end_line": 104,
+            "line": 107,
+            "end_line": 107,
             "column": 2,
             "end_column": 17
           },
@@ -4145,8 +4510,8 @@
             "_type": "ArrayExtend",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 104,
-              "end_line": 104,
+              "line": 107,
+              "end_line": 107,
               "column": 2,
               "end_column": 17
             },
@@ -4161,8 +4526,8 @@
               "_type": "VarExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 104,
-                "end_line": 104,
+                "line": 107,
+                "end_line": 107,
                 "column": 2,
                 "end_column": 9
               },
@@ -4198,8 +4563,8 @@
               "_type": "TupleExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 104,
-                "end_line": 104,
+                "line": 107,
+                "end_line": 107,
                 "column": 2,
                 "end_column": 17
               },
@@ -4233,8 +4598,8 @@
                   "_type": "VarExpression",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 104,
-                    "end_line": 104,
+                    "line": 107,
+                    "end_line": 107,
                     "column": 15,
                     "end_column": 16
                   },
@@ -4264,8 +4629,8 @@
           "_type": "AssignmentStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 106,
-            "end_line": 106,
+            "line": 109,
+            "end_line": 109,
             "column": 8,
             "end_column": 45
           },
@@ -4273,8 +4638,8 @@
             "_type": "VarExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 106,
-              "end_line": 106,
+              "line": 109,
+              "end_line": 109,
               "column": 8,
               "end_column": 19
             },
@@ -4310,8 +4675,8 @@
             "_type": "ArrayConcat",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 106,
-              "end_line": 106,
+              "line": 109,
+              "end_line": 109,
               "column": 22,
               "end_column": 45
             },
@@ -4345,8 +4710,8 @@
               "_type": "VarExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 106,
-                "end_line": 106,
+                "line": 109,
+                "end_line": 109,
                 "column": 22,
                 "end_column": 29
               },
@@ -4382,8 +4747,8 @@
               "_type": "VarExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 106,
-                "end_line": 106,
+                "line": 109,
+                "end_line": 109,
                 "column": 37,
                 "end_column": 44
               },
@@ -4421,8 +4786,8 @@
           "_type": "ExpressionStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 108,
-            "end_line": 108,
+            "line": 111,
+            "end_line": 111,
             "column": 2,
             "end_column": 66
           },
@@ -4430,8 +4795,8 @@
             "_type": "AssertExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 108,
-              "end_line": 108,
+              "line": 111,
+              "end_line": 111,
               "column": 2,
               "end_column": 66
             },
@@ -4446,8 +4811,8 @@
               "_type": "BytesComparisonExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 108,
-                "end_line": 108,
+                "line": 111,
+                "end_line": 111,
                 "column": 9,
                 "end_column": 65
               },
@@ -4462,8 +4827,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 108,
-                  "end_line": 108,
+                  "line": 111,
+                  "end_line": 111,
                   "column": 9,
                   "end_column": 65
                 },
@@ -4478,8 +4843,8 @@
                   "_type": "VarExpression",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 108,
-                    "end_line": 108,
+                    "line": 111,
+                    "end_line": 111,
                     "column": 9,
                     "end_column": 20
                   },
@@ -4517,8 +4882,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 108,
-                  "end_line": 108,
+                  "line": 111,
+                  "end_line": 111,
                   "column": 9,
                   "end_column": 65
                 },
@@ -4533,8 +4898,8 @@
                   "_type": "NewArray",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 108,
-                    "end_line": 108,
+                    "line": 111,
+                    "end_line": 111,
                     "column": 25,
                     "end_column": 65
                   },
@@ -4564,8 +4929,8 @@
                     },
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 108,
-                      "end_line": 108,
+                      "line": 111,
+                      "end_line": 111,
                       "column": 25,
                       "end_column": 65
                     }
@@ -4575,8 +4940,8 @@
                       "_type": "VarExpression",
                       "source_location": {
                         "file": "tests/approvals/arc4-types.algo.ts",
-                        "line": 108,
-                        "end_line": 108,
+                        "line": 111,
+                        "end_line": 111,
                         "column": 42,
                         "end_column": 43
                       },
@@ -4602,8 +4967,8 @@
                       "_type": "VarExpression",
                       "source_location": {
                         "file": "tests/approvals/arc4-types.algo.ts",
-                        "line": 108,
-                        "end_line": 108,
+                        "line": 111,
+                        "end_line": 111,
                         "column": 45,
                         "end_column": 46
                       },
@@ -4629,8 +4994,8 @@
                       "_type": "VarExpression",
                       "source_location": {
                         "file": "tests/approvals/arc4-types.algo.ts",
-                        "line": 108,
-                        "end_line": 108,
+                        "line": 111,
+                        "end_line": 111,
                         "column": 48,
                         "end_column": 49
                       },
@@ -4656,8 +5021,8 @@
                       "_type": "VarExpression",
                       "source_location": {
                         "file": "tests/approvals/arc4-types.algo.ts",
-                        "line": 108,
-                        "end_line": 108,
+                        "line": 111,
+                        "end_line": 111,
                         "column": 51,
                         "end_column": 52
                       },
@@ -4683,8 +5048,8 @@
                       "_type": "VarExpression",
                       "source_location": {
                         "file": "tests/approvals/arc4-types.algo.ts",
-                        "line": 108,
-                        "end_line": 108,
+                        "line": 111,
+                        "end_line": 111,
                         "column": 54,
                         "end_column": 55
                       },
@@ -4710,8 +5075,8 @@
                       "_type": "VarExpression",
                       "source_location": {
                         "file": "tests/approvals/arc4-types.algo.ts",
-                        "line": 108,
-                        "end_line": 108,
+                        "line": 111,
+                        "end_line": 111,
                         "column": 57,
                         "end_column": 58
                       },
@@ -4737,8 +5102,8 @@
                       "_type": "VarExpression",
                       "source_location": {
                         "file": "tests/approvals/arc4-types.algo.ts",
-                        "line": 108,
-                        "end_line": 108,
+                        "line": 111,
+                        "end_line": 111,
                         "column": 60,
                         "end_column": 61
                       },
@@ -4764,8 +5129,8 @@
                       "_type": "VarExpression",
                       "source_location": {
                         "file": "tests/approvals/arc4-types.algo.ts",
-                        "line": 108,
-                        "end_line": 108,
+                        "line": 111,
+                        "end_line": 111,
                         "column": 63,
                         "end_column": 64
                       },
@@ -4798,8 +5163,8 @@
           "_type": "AssignmentStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 110,
-            "end_line": 110,
+            "line": 113,
+            "end_line": 113,
             "column": 8,
             "end_column": 40
           },
@@ -4807,8 +5172,8 @@
             "_type": "VarExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 110,
-              "end_line": 110,
+              "line": 113,
+              "end_line": 113,
               "column": 8,
               "end_column": 16
             },
@@ -4845,8 +5210,8 @@
             "_type": "NewArray",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 110,
-              "end_line": 110,
+              "line": 113,
+              "end_line": 113,
               "column": 19,
               "end_column": 40
             },
@@ -4882,8 +5247,8 @@
                 "_type": "VarExpression",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 110,
-                  "end_line": 110,
+                  "line": 113,
+                  "end_line": 113,
                   "column": 35,
                   "end_column": 36
                 },
@@ -4909,8 +5274,8 @@
                 "_type": "VarExpression",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 110,
-                  "end_line": 110,
+                  "line": 113,
+                  "end_line": 113,
                   "column": 38,
                   "end_column": 39
                 },
@@ -4939,8 +5304,8 @@
           "_type": "ExpressionStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 112,
-            "end_line": 112,
+            "line": 115,
+            "end_line": 115,
             "column": 2,
             "end_column": 39
           },
@@ -4948,8 +5313,8 @@
             "_type": "AssertExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 112,
-              "end_line": 112,
+              "line": 115,
+              "end_line": 115,
               "column": 2,
               "end_column": 39
             },
@@ -4964,8 +5329,8 @@
               "_type": "BytesComparisonExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 112,
-                "end_line": 112,
+                "line": 115,
+                "end_line": 115,
                 "column": 9,
                 "end_column": 38
               },
@@ -4980,8 +5345,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 112,
-                  "end_line": 112,
+                  "line": 115,
+                  "end_line": 115,
                   "column": 9,
                   "end_column": 38
                 },
@@ -4996,8 +5361,8 @@
                   "_type": "IndexExpression",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 112,
-                    "end_line": 112,
+                    "line": 115,
+                    "end_line": 115,
                     "column": 9,
                     "end_column": 20
                   },
@@ -5021,8 +5386,8 @@
                     "_type": "VarExpression",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 112,
-                      "end_line": 112,
+                      "line": 115,
+                      "end_line": 115,
                       "column": 9,
                       "end_column": 17
                     },
@@ -5059,8 +5424,8 @@
                     "_type": "IntegerConstant",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 112,
-                      "end_line": 112,
+                      "line": 115,
+                      "end_line": 115,
                       "column": 18,
                       "end_column": 19
                     },
@@ -5081,8 +5446,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 112,
-                  "end_line": 112,
+                  "line": 115,
+                  "end_line": 115,
                   "column": 9,
                   "end_column": 38
                 },
@@ -5097,8 +5462,8 @@
                   "_type": "ArrayPop",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 112,
-                    "end_line": 112,
+                    "line": 115,
+                    "end_line": 115,
                     "column": 25,
                     "end_column": 38
                   },
@@ -5122,8 +5487,8 @@
                     "_type": "VarExpression",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 112,
-                      "end_line": 112,
+                      "line": 115,
+                      "end_line": 115,
                       "column": 25,
                       "end_column": 32
                     },
@@ -5165,8 +5530,8 @@
           "_type": "AssignmentStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 114,
-            "end_line": 114,
+            "line": 117,
+            "end_line": 117,
             "column": 2,
             "end_column": 33
           },
@@ -5174,8 +5539,8 @@
             "_type": "IndexExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 114,
-              "end_line": 114,
+              "line": 117,
+              "end_line": 117,
               "column": 2,
               "end_column": 13
             },
@@ -5199,8 +5564,8 @@
               "_type": "VarExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 114,
-                "end_line": 114,
+                "line": 117,
+                "end_line": 117,
                 "column": 2,
                 "end_column": 10
               },
@@ -5237,8 +5602,8 @@
               "_type": "IntegerConstant",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 114,
-                "end_line": 114,
+                "line": 117,
+                "end_line": 117,
                 "column": 11,
                 "end_column": 12
               },
@@ -5257,8 +5622,8 @@
             "_type": "IntegerConstant",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 114,
-              "end_line": 114,
+              "line": 117,
+              "end_line": 117,
               "column": 16,
               "end_column": 33
             },
@@ -5286,8 +5651,8 @@
           "_type": "AssignmentStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 116,
-            "end_line": 116,
+            "line": 119,
+            "end_line": 119,
             "column": 8,
             "end_column": 59
           },
@@ -5295,8 +5660,8 @@
             "_type": "VarExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 116,
-              "end_line": 116,
+              "line": 119,
+              "end_line": 119,
               "column": 8,
               "end_column": 17
             },
@@ -5333,8 +5698,8 @@
             "_type": "NewArray",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 116,
-              "end_line": 116,
+              "line": 119,
+              "end_line": 119,
               "column": 20,
               "end_column": 59
             },
@@ -5370,8 +5735,8 @@
                 "_type": "VarExpression",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 116,
-                  "end_line": 116,
+                  "line": 119,
+                  "end_line": 119,
                   "column": 51,
                   "end_column": 52
                 },
@@ -5397,8 +5762,8 @@
                 "_type": "VarExpression",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 116,
-                  "end_line": 116,
+                  "line": 119,
+                  "end_line": 119,
                   "column": 54,
                   "end_column": 55
                 },
@@ -5424,8 +5789,8 @@
                 "_type": "VarExpression",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 116,
-                  "end_line": 116,
+                  "line": 119,
+                  "end_line": 119,
                   "column": 57,
                   "end_column": 58
                 },
@@ -5468,8 +5833,8 @@
     "_type": "Subroutine",
     "source_location": {
       "file": "tests/approvals/arc4-types.algo.ts",
-      "line": 119,
-      "end_line": 119,
+      "line": 122,
+      "end_line": 122,
       "column": 0,
       "end_column": 19
     },
@@ -5485,8 +5850,8 @@
       "_type": "Block",
       "source_location": {
         "file": "tests/approvals/arc4-types.algo.ts",
-        "line": 119,
-        "end_line": 123,
+        "line": 122,
+        "end_line": 126,
         "column": 20,
         "end_column": 1
       },
@@ -5495,8 +5860,8 @@
           "_type": "ExpressionStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 122,
-            "end_line": 122,
+            "line": 125,
+            "end_line": 125,
             "column": 2,
             "end_column": 18
           },
@@ -5504,8 +5869,8 @@
             "_type": "AssertExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 122,
-              "end_line": 122,
+              "line": 125,
+              "end_line": 125,
               "column": 2,
               "end_column": 18
             },
@@ -5520,8 +5885,8 @@
               "_type": "BytesComparisonExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 122,
-                "end_line": 122,
+                "line": 125,
+                "end_line": 125,
                 "column": 9,
                 "end_column": 17
               },
@@ -5536,8 +5901,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 122,
-                  "end_line": 122,
+                  "line": 125,
+                  "end_line": 125,
                   "column": 9,
                   "end_column": 17
                 },
@@ -5552,8 +5917,8 @@
                   "_type": "IntegerConstant",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 120,
-                    "end_line": 120,
+                    "line": 123,
+                    "end_line": 123,
                     "column": 12,
                     "end_column": 22
                   },
@@ -5582,8 +5947,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 122,
-                  "end_line": 122,
+                  "line": 125,
+                  "end_line": 125,
                   "column": 9,
                   "end_column": 17
                 },
@@ -5598,8 +5963,8 @@
                   "_type": "IntegerConstant",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 121,
-                    "end_line": 121,
+                    "line": 124,
+                    "end_line": 124,
                     "column": 13,
                     "end_column": 24
                   },
@@ -5645,8 +6010,8 @@
     "_type": "Subroutine",
     "source_location": {
       "file": "tests/approvals/arc4-types.algo.ts",
-      "line": 125,
-      "end_line": 125,
+      "line": 128,
+      "end_line": 128,
       "column": 0,
       "end_column": 22
     },
@@ -5662,8 +6027,8 @@
       "_type": "Block",
       "source_location": {
         "file": "tests/approvals/arc4-types.algo.ts",
-        "line": 125,
-        "end_line": 132,
+        "line": 128,
+        "end_line": 135,
         "column": 23,
         "end_column": 1
       },
@@ -5672,8 +6037,8 @@
           "_type": "AssignmentStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 127,
-            "end_line": 127,
+            "line": 130,
+            "end_line": 130,
             "column": 8,
             "end_column": 35
           },
@@ -5681,8 +6046,8 @@
             "_type": "VarExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 127,
-              "end_line": 127,
+              "line": 130,
+              "end_line": 130,
               "column": 8,
               "end_column": 9
             },
@@ -5725,8 +6090,8 @@
             "_type": "ReinterpretCast",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 127,
-              "end_line": 127,
+              "line": 130,
+              "end_line": 130,
               "column": 12,
               "end_column": 35
             },
@@ -5767,8 +6132,8 @@
               "_type": "IntrinsicCall",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 127,
-                "end_line": 127,
+                "line": 130,
+                "end_line": 130,
                 "column": 28,
                 "end_column": 34
               },
@@ -5791,8 +6156,8 @@
           "_type": "ExpressionStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 129,
-            "end_line": 129,
+            "line": 132,
+            "end_line": 132,
             "column": 2,
             "end_column": 57
           },
@@ -5800,8 +6165,8 @@
             "_type": "AssertExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 129,
-              "end_line": 129,
+              "line": 132,
+              "end_line": 132,
               "column": 2,
               "end_column": 57
             },
@@ -5816,8 +6181,8 @@
               "_type": "BytesComparisonExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 129,
-                "end_line": 129,
+                "line": 132,
+                "end_line": 132,
                 "column": 9,
                 "end_column": 16
               },
@@ -5832,8 +6197,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 129,
-                  "end_line": 129,
+                  "line": 132,
+                  "end_line": 132,
                   "column": 9,
                   "end_column": 16
                 },
@@ -5848,8 +6213,8 @@
                   "_type": "AddressConstant",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 126,
-                    "end_line": 126,
+                    "line": 129,
+                    "end_line": 129,
                     "column": 12,
                     "end_column": 25
                   },
@@ -5894,8 +6259,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 129,
-                  "end_line": 129,
+                  "line": 132,
+                  "end_line": 132,
                   "column": 9,
                   "end_column": 16
                 },
@@ -5910,8 +6275,8 @@
                   "_type": "VarExpression",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 129,
-                    "end_line": 129,
+                    "line": 132,
+                    "end_line": 132,
                     "column": 15,
                     "end_column": 16
                   },
@@ -5959,8 +6324,8 @@
           "_type": "ExpressionStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 130,
-            "end_line": 130,
+            "line": 133,
+            "end_line": 133,
             "column": 2,
             "end_column": 64
           },
@@ -5968,8 +6333,8 @@
             "_type": "AssertExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 130,
-              "end_line": 130,
+              "line": 133,
+              "end_line": 133,
               "column": 2,
               "end_column": 64
             },
@@ -5984,8 +6349,8 @@
               "_type": "BytesComparisonExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 130,
-                "end_line": 130,
+                "line": 133,
+                "end_line": 133,
                 "column": 9,
                 "end_column": 28
               },
@@ -6000,8 +6365,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 130,
-                  "end_line": 130,
+                  "line": 133,
+                  "end_line": 133,
                   "column": 9,
                   "end_column": 28
                 },
@@ -6016,8 +6381,8 @@
                   "_type": "AddressConstant",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 126,
-                    "end_line": 126,
+                    "line": 129,
+                    "end_line": 129,
                     "column": 12,
                     "end_column": 25
                   },
@@ -6062,8 +6427,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 130,
-                  "end_line": 130,
+                  "line": 133,
+                  "end_line": 133,
                   "column": 9,
                   "end_column": 28
                 },
@@ -6078,8 +6443,8 @@
                   "_type": "AddressConstant",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 130,
-                    "end_line": 130,
+                    "line": 133,
+                    "end_line": 133,
                     "column": 15,
                     "end_column": 28
                   },
@@ -6127,8 +6492,8 @@
           "_type": "ExpressionStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 131,
-            "end_line": 131,
+            "line": 134,
+            "end_line": 134,
             "column": 2,
             "end_column": 73
           },
@@ -6136,8 +6501,8 @@
             "_type": "AssertExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 131,
-              "end_line": 131,
+              "line": 134,
+              "end_line": 134,
               "column": 2,
               "end_column": 73
             },
@@ -6152,8 +6517,8 @@
               "_type": "BytesComparisonExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 131,
-                "end_line": 131,
+                "line": 134,
+                "end_line": 134,
                 "column": 9,
                 "end_column": 28
               },
@@ -6168,8 +6533,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 131,
-                  "end_line": 131,
+                  "line": 134,
+                  "end_line": 134,
                   "column": 9,
                   "end_column": 28
                 },
@@ -6184,8 +6549,8 @@
                   "_type": "IndexExpression",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 131,
-                    "end_line": 131,
+                    "line": 134,
+                    "end_line": 134,
                     "column": 9,
                     "end_column": 13
                   },
@@ -6209,8 +6574,8 @@
                     "_type": "AddressConstant",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 126,
-                      "end_line": 126,
+                      "line": 129,
+                      "end_line": 129,
                       "column": 12,
                       "end_column": 25
                     },
@@ -6253,8 +6618,8 @@
                     "_type": "IntegerConstant",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 131,
-                      "end_line": 131,
+                      "line": 134,
+                      "end_line": 134,
                       "column": 11,
                       "end_column": 12
                     },
@@ -6275,8 +6640,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 131,
-                  "end_line": 131,
+                  "line": 134,
+                  "end_line": 134,
                   "column": 9,
                   "end_column": 28
                 },
@@ -6291,8 +6656,8 @@
                   "_type": "IntegerConstant",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 131,
-                    "end_line": 131,
+                    "line": 134,
+                    "end_line": 134,
                     "column": 18,
                     "end_column": 28
                   },
@@ -6338,8 +6703,8 @@
     "_type": "Subroutine",
     "source_location": {
       "file": "tests/approvals/arc4-types.algo.ts",
-      "line": 134,
-      "end_line": 134,
+      "line": 137,
+      "end_line": 137,
       "column": 0,
       "end_column": 20
     },
@@ -6355,8 +6720,8 @@
       "_type": "Block",
       "source_location": {
         "file": "tests/approvals/arc4-types.algo.ts",
-        "line": 134,
-        "end_line": 141,
+        "line": 137,
+        "end_line": 144,
         "column": 21,
         "end_column": 1
       },
@@ -6365,8 +6730,8 @@
           "_type": "AssignmentStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 135,
-            "end_line": 135,
+            "line": 138,
+            "end_line": 138,
             "column": 8,
             "end_column": 41
           },
@@ -6374,8 +6739,8 @@
             "_type": "VarExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 135,
-              "end_line": 135,
+              "line": 138,
+              "end_line": 138,
               "column": 8,
               "end_column": 9
             },
@@ -6413,8 +6778,8 @@
             "_type": "ARC4Encode",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 135,
-              "end_line": 135,
+              "line": 138,
+              "end_line": 138,
               "column": 12,
               "end_column": 41
             },
@@ -6446,8 +6811,8 @@
               ],
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 135,
-                "end_line": 135,
+                "line": 138,
+                "end_line": 138,
                 "column": 12,
                 "end_column": 41
               }
@@ -6456,8 +6821,8 @@
               "_type": "TupleExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 135,
-                "end_line": 135,
+                "line": 138,
+                "end_line": 138,
                 "column": 12,
                 "end_column": 41
               },
@@ -6491,8 +6856,8 @@
                   "_type": "IntegerConstant",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 135,
-                    "end_line": 135,
+                    "line": 138,
+                    "end_line": 138,
                     "column": 22,
                     "end_column": 40
                   },
@@ -6523,8 +6888,8 @@
           "_type": "AssignmentStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 136,
-            "end_line": 136,
+            "line": 139,
+            "end_line": 139,
             "column": 8,
             "end_column": 27
           },
@@ -6532,8 +6897,8 @@
             "_type": "VarExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 136,
-              "end_line": 136,
+              "line": 139,
+              "end_line": 139,
               "column": 8,
               "end_column": 17
             },
@@ -6559,8 +6924,8 @@
             "_type": "TupleItemExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 136,
-              "end_line": 136,
+              "line": 139,
+              "end_line": 139,
               "column": 20,
               "end_column": 27
             },
@@ -6584,8 +6949,8 @@
               "_type": "VarExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 136,
-                "end_line": 136,
+                "line": 139,
+                "end_line": 139,
                 "column": 20,
                 "end_column": 21
               },
@@ -6626,8 +6991,8 @@
           "_type": "AssignmentStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 137,
-            "end_line": 137,
+            "line": 140,
+            "end_line": 140,
             "column": 8,
             "end_column": 38
           },
@@ -6635,8 +7000,8 @@
             "_type": "VarExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 137,
-              "end_line": 137,
+              "line": 140,
+              "end_line": 140,
               "column": 8,
               "end_column": 24
             },
@@ -6662,8 +7027,8 @@
             "_type": "TupleItemExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 137,
-              "end_line": 137,
+              "line": 140,
+              "end_line": 140,
               "column": 27,
               "end_column": 38
             },
@@ -6687,8 +7052,8 @@
               "_type": "ARC4Decode",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 137,
-                "end_line": 137,
+                "line": 140,
+                "end_line": 140,
                 "column": 29,
                 "end_column": 35
               },
@@ -6721,8 +7086,8 @@
                 "_type": "VarExpression",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 137,
-                  "end_line": 137,
+                  "line": 140,
+                  "end_line": 140,
                   "column": 27,
                   "end_column": 28
                 },
@@ -6764,8 +7129,8 @@
           "_type": "ExpressionStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 138,
-            "end_line": 138,
+            "line": 141,
+            "end_line": 141,
             "column": 2,
             "end_column": 40
           },
@@ -6773,8 +7138,8 @@
             "_type": "AssertExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 138,
-              "end_line": 138,
+              "line": 141,
+              "end_line": 141,
               "column": 2,
               "end_column": 40
             },
@@ -6789,8 +7154,8 @@
               "_type": "BytesComparisonExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 138,
-                "end_line": 138,
+                "line": 141,
+                "end_line": 141,
                 "column": 9,
                 "end_column": 39
               },
@@ -6805,8 +7170,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 138,
-                  "end_line": 138,
+                  "line": 141,
+                  "end_line": 141,
                   "column": 9,
                   "end_column": 39
                 },
@@ -6821,8 +7186,8 @@
                   "_type": "VarExpression",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 138,
-                    "end_line": 138,
+                    "line": 141,
+                    "end_line": 141,
                     "column": 9,
                     "end_column": 18
                   },
@@ -6850,8 +7215,8 @@
                 "_type": "ReinterpretCast",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 138,
-                  "end_line": 138,
+                  "line": 141,
+                  "end_line": 141,
                   "column": 9,
                   "end_column": 39
                 },
@@ -6866,8 +7231,8 @@
                   "_type": "VarExpression",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 138,
-                    "end_line": 138,
+                    "line": 141,
+                    "end_line": 141,
                     "column": 23,
                     "end_column": 39
                   },
@@ -6898,8 +7263,8 @@
           "_type": "AssignmentStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 139,
-            "end_line": 139,
+            "line": 142,
+            "end_line": 142,
             "column": 8,
             "end_column": 49
           },
@@ -6907,8 +7272,8 @@
             "_type": "VarExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 139,
-              "end_line": 139,
+              "line": 142,
+              "end_line": 142,
               "column": 8,
               "end_column": 10
             },
@@ -6979,8 +7344,8 @@
             "_type": "ARC4Encode",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 139,
-              "end_line": 139,
+              "line": 142,
+              "end_line": 142,
               "column": 13,
               "end_column": 49
             },
@@ -7045,8 +7410,8 @@
               ],
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 139,
-                "end_line": 139,
+                "line": 142,
+                "end_line": 142,
                 "column": 13,
                 "end_column": 49
               }
@@ -7055,8 +7420,8 @@
               "_type": "TupleExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 139,
-                "end_line": 139,
+                "line": 142,
+                "end_line": 142,
                 "column": 13,
                 "end_column": 49
               },
@@ -7123,8 +7488,8 @@
                   "_type": "AddressConstant",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 139,
-                    "end_line": 139,
+                    "line": 142,
+                    "end_line": 142,
                     "column": 23,
                     "end_column": 36
                   },
@@ -7167,8 +7532,8 @@
                   "_type": "IntegerConstant",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 139,
-                    "end_line": 139,
+                    "line": 142,
+                    "end_line": 142,
                     "column": 38,
                     "end_column": 48
                   },
@@ -7199,8 +7564,8 @@
           "_type": "ExpressionStatement",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 140,
-            "end_line": 140,
+            "line": 143,
+            "end_line": 143,
             "column": 2,
             "end_column": 25
           },
@@ -7208,8 +7573,8 @@
             "_type": "AssertExpression",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 140,
-              "end_line": 140,
+              "line": 143,
+              "end_line": 143,
               "column": 2,
               "end_column": 25
             },
@@ -7224,8 +7589,8 @@
               "_type": "NumericComparisonExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 140,
-                "end_line": 140,
+                "line": 143,
+                "end_line": 143,
                 "column": 9,
                 "end_column": 24
               },
@@ -7240,8 +7605,8 @@
                 "_type": "IntegerConstant",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 140,
-                  "end_line": 140,
+                  "line": 143,
+                  "end_line": 143,
                   "column": 12,
                   "end_column": 18
                 },
@@ -7260,8 +7625,8 @@
                 "_type": "IntegerConstant",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 140,
-                  "end_line": 140,
+                  "line": 143,
+                  "end_line": 143,
                   "column": 23,
                   "end_column": 24
                 },
@@ -7297,8 +7662,8 @@
     "_type": "Contract",
     "source_location": {
       "file": "tests/approvals/arc4-types.algo.ts",
-      "line": 143,
-      "end_line": 143,
+      "line": 146,
+      "end_line": 146,
       "column": 0,
       "end_column": 57
     },
@@ -7312,8 +7677,8 @@
       "_type": "ContractMethod",
       "source_location": {
         "file": "tests/approvals/arc4-types.algo.ts",
-        "line": 148,
-        "end_line": 148,
+        "line": 151,
+        "end_line": 151,
         "column": 2,
         "end_column": 35
       },
@@ -7329,8 +7694,8 @@
         "_type": "Block",
         "source_location": {
           "file": "tests/approvals/arc4-types.algo.ts",
-          "line": 148,
-          "end_line": 163,
+          "line": 151,
+          "end_line": 166,
           "column": 36,
           "end_column": 3
         },
@@ -7339,8 +7704,8 @@
             "_type": "ExpressionStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 150,
-              "end_line": 150,
+              "line": 153,
+              "end_line": 153,
               "column": 4,
               "end_column": 13
             },
@@ -7348,8 +7713,8 @@
               "_type": "SubroutineCallExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 150,
-                "end_line": 150,
+                "line": 153,
+                "end_line": 153,
                 "column": 4,
                 "end_column": 13
               },
@@ -7371,8 +7736,8 @@
             "_type": "ExpressionStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 151,
-              "end_line": 151,
+              "line": 154,
+              "end_line": 154,
               "column": 4,
               "end_column": 39
             },
@@ -7380,8 +7745,8 @@
               "_type": "SubroutineCallExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 151,
-                "end_line": 151,
+                "line": 154,
+                "end_line": 154,
                 "column": 4,
                 "end_column": 39
               },
@@ -7404,8 +7769,8 @@
                     "_type": "IntegerConstant",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 151,
-                      "end_line": 151,
+                      "line": 154,
+                      "end_line": 154,
                       "column": 14,
                       "end_column": 15
                     },
@@ -7427,8 +7792,8 @@
                     "_type": "IntegerConstant",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 151,
-                      "end_line": 151,
+                      "line": 154,
+                      "end_line": 154,
                       "column": 17,
                       "end_column": 19
                     },
@@ -7450,8 +7815,8 @@
                     "_type": "IntegerConstant",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 151,
-                      "end_line": 151,
+                      "line": 154,
+                      "end_line": 154,
                       "column": 21,
                       "end_column": 38
                     },
@@ -7482,8 +7847,8 @@
             "_type": "ExpressionStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 152,
-              "end_line": 152,
+              "line": 155,
+              "end_line": 155,
               "column": 4,
               "end_column": 16
             },
@@ -7491,8 +7856,8 @@
               "_type": "SubroutineCallExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 152,
-                "end_line": 152,
+                "line": 155,
+                "end_line": 155,
                 "column": 4,
                 "end_column": 16
               },
@@ -7514,8 +7879,8 @@
             "_type": "ExpressionStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 153,
-              "end_line": 153,
+              "line": 156,
+              "end_line": 156,
               "column": 4,
               "end_column": 14
             },
@@ -7523,8 +7888,8 @@
               "_type": "SubroutineCallExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 153,
-                "end_line": 153,
+                "line": 156,
+                "end_line": 156,
                 "column": 4,
                 "end_column": 14
               },
@@ -7546,8 +7911,8 @@
             "_type": "ExpressionStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 154,
-              "end_line": 154,
+              "line": 157,
+              "end_line": 157,
               "column": 4,
               "end_column": 33
             },
@@ -7555,8 +7920,8 @@
               "_type": "SubroutineCallExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 154,
-                "end_line": 154,
+                "line": 157,
+                "end_line": 157,
                 "column": 4,
                 "end_column": 33
               },
@@ -7579,8 +7944,8 @@
                     "_type": "IntegerConstant",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 154,
-                      "end_line": 154,
+                      "line": 157,
+                      "end_line": 157,
                       "column": 15,
                       "end_column": 32
                     },
@@ -7611,8 +7976,8 @@
             "_type": "ExpressionStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 155,
-              "end_line": 155,
+              "line": 158,
+              "end_line": 158,
               "column": 4,
               "end_column": 17
             },
@@ -7620,8 +7985,8 @@
               "_type": "SubroutineCallExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 155,
-                "end_line": 155,
+                "line": 158,
+                "end_line": 158,
                 "column": 4,
                 "end_column": 17
               },
@@ -7643,8 +8008,8 @@
             "_type": "ExpressionStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 156,
-              "end_line": 156,
+              "line": 159,
+              "end_line": 159,
               "column": 4,
               "end_column": 15
             },
@@ -7652,8 +8017,8 @@
               "_type": "SubroutineCallExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 156,
-                "end_line": 156,
+                "line": 159,
+                "end_line": 159,
                 "column": 4,
                 "end_column": 15
               },
@@ -7675,8 +8040,8 @@
             "_type": "ExpressionStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 157,
-              "end_line": 157,
+              "line": 160,
+              "end_line": 160,
               "column": 4,
               "end_column": 16
             },
@@ -7684,8 +8049,8 @@
               "_type": "SubroutineCallExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 157,
-                "end_line": 157,
+                "line": 160,
+                "end_line": 160,
                 "column": 4,
                 "end_column": 16
               },
@@ -7707,8 +8072,8 @@
             "_type": "ExpressionStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 158,
-              "end_line": 158,
+              "line": 161,
+              "end_line": 161,
               "column": 4,
               "end_column": 41
             },
@@ -7716,8 +8081,8 @@
               "_type": "SubroutineCallExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 158,
-                "end_line": 158,
+                "line": 161,
+                "end_line": 161,
                 "column": 4,
                 "end_column": 41
               },
@@ -7740,8 +8105,8 @@
                     "_type": "BytesConstant",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 158,
-                      "end_line": 158,
+                      "line": 161,
+                      "end_line": 161,
                       "column": 27,
                       "end_column": 39
                     },
@@ -7763,8 +8128,8 @@
             "_type": "ExpressionStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 159,
-              "end_line": 159,
+              "line": 162,
+              "end_line": 162,
               "column": 4,
               "end_column": 21
             },
@@ -7772,8 +8137,8 @@
               "_type": "SubroutineCallExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 159,
-                "end_line": 159,
+                "line": 162,
+                "end_line": 162,
                 "column": 4,
                 "end_column": 21
               },
@@ -7795,8 +8160,8 @@
             "_type": "AssignmentStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 160,
-              "end_line": 160,
+              "line": 163,
+              "end_line": 163,
               "column": 10,
               "end_column": 58
             },
@@ -7804,8 +8169,8 @@
               "_type": "VarExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 160,
-                "end_line": 160,
+                "line": 163,
+                "end_line": 163,
                 "column": 10,
                 "end_column": 16
               },
@@ -7841,8 +8206,8 @@
               "_type": "NewArray",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 160,
-                "end_line": 160,
+                "line": 163,
+                "end_line": 163,
                 "column": 19,
                 "end_column": 58
               },
@@ -7872,8 +8237,8 @@
                 },
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 160,
-                  "end_line": 160,
+                  "line": 163,
+                  "end_line": 163,
                   "column": 19,
                   "end_column": 58
                 }
@@ -7885,8 +8250,8 @@
             "_type": "ExpressionStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 161,
-              "end_line": 161,
+              "line": 164,
+              "end_line": 164,
               "column": 4,
               "end_column": 31
             },
@@ -7894,8 +8259,8 @@
               "_type": "AssertExpression",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 161,
-                "end_line": 161,
+                "line": 164,
+                "end_line": 164,
                 "column": 4,
                 "end_column": 31
               },
@@ -7910,8 +8275,8 @@
                 "_type": "NumericComparisonExpression",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 161,
-                  "end_line": 161,
+                  "line": 164,
+                  "end_line": 164,
                   "column": 11,
                   "end_column": 30
                 },
@@ -7926,8 +8291,8 @@
                   "_type": "ArrayLength",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 161,
-                    "end_line": 161,
+                    "line": 164,
+                    "end_line": 164,
                     "column": 18,
                     "end_column": 24
                   },
@@ -7942,8 +8307,8 @@
                     "_type": "VarExpression",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 161,
-                      "end_line": 161,
+                      "line": 164,
+                      "end_line": 164,
                       "column": 11,
                       "end_column": 17
                     },
@@ -7981,8 +8346,8 @@
                   "_type": "IntegerConstant",
                   "source_location": {
                     "file": "tests/approvals/arc4-types.algo.ts",
-                    "line": 161,
-                    "end_line": 161,
+                    "line": 164,
+                    "end_line": 164,
                     "column": 29,
                     "end_column": 30
                   },
@@ -8004,8 +8369,8 @@
             "_type": "ReturnStatement",
             "source_location": {
               "file": "tests/approvals/arc4-types.algo.ts",
-              "line": 162,
-              "end_line": 162,
+              "line": 165,
+              "end_line": 165,
               "column": 4,
               "end_column": 15
             },
@@ -8013,8 +8378,8 @@
               "_type": "BoolConstant",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 162,
-                "end_line": 162,
+                "line": 165,
+                "end_line": 165,
                 "column": 11,
                 "end_column": 15
               },
@@ -8122,8 +8487,8 @@
         "_type": "ContractMethod",
         "source_location": {
           "file": "tests/approvals/arc4-types.algo.ts",
-          "line": 144,
-          "end_line": 144,
+          "line": 147,
+          "end_line": 147,
           "column": 2,
           "end_column": 51
         },
@@ -8206,8 +8571,8 @@
           "_type": "Block",
           "source_location": {
             "file": "tests/approvals/arc4-types.algo.ts",
-            "line": 144,
-            "end_line": 146,
+            "line": 147,
+            "end_line": 149,
             "column": 52,
             "end_column": 3
           },
@@ -8216,8 +8581,8 @@
               "_type": "ReturnStatement",
               "source_location": {
                 "file": "tests/approvals/arc4-types.algo.ts",
-                "line": 145,
-                "end_line": 145,
+                "line": 148,
+                "end_line": 148,
                 "column": 4,
                 "end_column": 54
               },
@@ -8225,8 +8590,8 @@
                 "_type": "TupleExpression",
                 "source_location": {
                   "file": "tests/approvals/arc4-types.algo.ts",
-                  "line": 145,
-                  "end_line": 145,
+                  "line": 148,
+                  "end_line": 148,
                   "column": 12,
                   "end_column": 53
                 },
@@ -8309,8 +8674,8 @@
                     "_type": "IntegerConstant",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 145,
-                      "end_line": 145,
+                      "line": 148,
+                      "end_line": 148,
                       "column": 12,
                       "end_column": 22
                     },
@@ -8337,8 +8702,8 @@
                     "_type": "IntegerConstant",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 145,
-                      "end_line": 145,
+                      "line": 148,
+                      "end_line": 148,
                       "column": 24,
                       "end_column": 38
                     },
@@ -8365,8 +8730,8 @@
                     "_type": "AddressConstant",
                     "source_location": {
                       "file": "tests/approvals/arc4-types.algo.ts",
-                      "line": 145,
-                      "end_line": 145,
+                      "line": 148,
+                      "end_line": 148,
                       "column": 40,
                       "end_column": 53
                     },


### PR DESCRIPTION
-  fix the following error when calling `new StaticBytes<32>().native` in `puya-ts`.
  ```
  error: ARC4Decode.value: expression of WType arc4.static_array<arc4.uint8, 33> received, expected arc4.bool or ARC4UIntN or ARC4Tuple or ARC4Struct or ARC4DynamicArray
  ```
- caused by `StaticArrayExpressionBuilder` being selected for `StaticBytesType` in `tryGetInstanceEb` function of `TypeRegistry` because the specific type is added to the registry after the base type. 
- fix by moving the specific type registration above the base type registration