### PR TITLE
fix: Windows path comparison + diagnostics paths

### DIFF
--- a/src/language-server/diagnostics.ts
+++ b/src/language-server/diagnostics.ts
@@ -1,3 +1,4 @@
+import upath from 'upath'
 import type { Connection, Diagnostic } from 'vscode-languageserver'
 import { DiagnosticSeverity } from 'vscode-languageserver'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
@@ -79,7 +80,10 @@ export async function getWorkspaceDiagnostics(
 
     return files.reduce((acc, file) => {
       const diagnostics = logEvents.filter((e) => e.sourceLocation.file === file.sourceFile).map(mapToDiagnostic)
-      acc.set(URI.file(file.sourceFile).toString(), diagnostics)
+      acc.set(
+        URI.file(upath.isAbsolute(file.sourceFile) ? file.sourceFile : upath.join(workspaceFolder, file.sourceFile)).toString(),
+        diagnostics,
+      )
       return acc
     }, new Map<string, Diagnostic[]>())
   } catch (error) {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -185,6 +185,7 @@ export function instanceOfAny<T extends Array<{ new (...args: DeliberateAny[]): 
  * @param workingDirectory
  */
 export function normalisePath(filePath: string, workingDirectory: string): string {
+  const isWindows = process.platform === 'win32'
   const localPackageName = /packages\/algo-ts\/dist\/(.*)$/.exec(filePath)
   if (localPackageName) {
     return `${Constants.algoTsPackage}/${localPackageName[1]}`
@@ -193,9 +194,10 @@ export function normalisePath(filePath: string, workingDirectory: string): strin
   if (nodeModuleName) {
     return nodeModuleName[1]
   }
+
   const cwd = upath.normalize(`${workingDirectory}/`)
   const normalizedPath = upath.normalize(filePath)
-  const moduleName = normalizedPath.startsWith(cwd) ? normalizedPath.slice(cwd.length) : normalizedPath
+  const moduleName = startsWith(normalizedPath, cwd, isWindows) ? normalizedPath.slice(cwd.length) : normalizedPath
   return moduleName.replaceAll('\\', '/')
 }
 
@@ -263,4 +265,11 @@ export function joinUint8Arrays(...arrays: Uint8Array[]): Uint8Array {
     offset += a.length
   }
   return result
+}
+
+export function startsWith(str: string, prefix: string, ignoreCase = false): boolean {
+  if (ignoreCase) {
+    return str.toLowerCase().startsWith(prefix.toLowerCase())
+  }
+  return str.startsWith(prefix)
 }


### PR DESCRIPTION
- On Windows, using case-insensitive path comparison
- Make sure that diagnostic file paths are absolute