### PR TITLE
Getting Started tips for first time contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,8 @@ To set up the project locally:
    ```sh
    npm test
    ```
+> [!TIP]
+> Windows users: The initial test run may fail due to CRLF/LF line ending differences. If so, run `git add .` which will force git to recognise and cache the new line endings and allow the tests to complete.
 
 ## Adding New Op Codes for New AVM Versions
 


### PR DESCRIPTION
When running tests in Windows the first time, they fail due to line ending differences.

Add some documentation for first-time users on how to resolve this.