### PR TITLE
fix: b64 charNum

### DIFF
--- a/src/util/base-64.ts
+++ b/src/util/base-64.ts
@@ -10,7 +10,7 @@ import { throwError } from '../errors'
 
 const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'.split('')
 
-const charToNum = new Map(alphabet.entries().map(([i, c]) => [c, i]))
+const charToNum = new Map([...alphabet.entries()].map(([i, c]) => [c, i]))
 const numToChar = new Map(alphabet.entries())
 
 function getCharForNum(n: number): string {


### PR DESCRIPTION
Currently it calls .map on .entries() which is an iterator and not an array. This PR converts the iterator to an array so we can call .map() on it. Fixes #253