### PR TITLE
refactor: use newScope as AlgorandFixture.beforeEach has been deprecated

### DIFF
--- a/tests/onchain/abi-decorators.spec.ts
+++ b/tests/onchain/abi-decorators.spec.ts
@@ -3,12 +3,15 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('abi-decorators', () => {
-  const test = createArc4TestFixture('tests/approvals/abi-decorators.algo.ts', {
-    AbiDecorators: { deployParams: { createParams: { method: 'createMethod' } } },
-    OverloadedMethods: {},
-    BaseAbi: {},
-    SubAbi: {},
-    SubAbi2: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/abi-decorators.algo.ts',
+    contracts: {
+      AbiDecorators: { deployParams: { createParams: { method: 'createMethod' } } },
+      OverloadedMethods: {},
+      BaseAbi: {},
+      SubAbi: {},
+      SubAbi2: {},
+    },
   })
   test('can be created', async ({ appFactoryAbiDecorators }) => {
     await appFactoryAbiDecorators.send.create({ method: 'createMethod' })

--- a/tests/onchain/abi-validation-exhaustive.spec.ts
+++ b/tests/onchain/abi-validation-exhaustive.spec.ts
@@ -40,7 +40,10 @@ function convertToBytes(sizeOrBytesValue: Uint8Array | number | (number | Uint8A
 }
 
 describe('abi validation exhaustive', () => {
-  const test = createArc4TestFixture('tests/approvals/abi-validation-exhaustive.algo.ts', { AbiValidationExhaustive: {} })
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/abi-validation-exhaustive.algo.ts',
+    contracts: { AbiValidationExhaustive: {} },
+  })
   test.for<[string, number | Uint8Array | (number | Uint8Array)[]]>([
     ['uint64', 8],
     ['ufixed64', 8],

--- a/tests/onchain/abi-validation.spec.ts
+++ b/tests/onchain/abi-validation.spec.ts
@@ -17,7 +17,7 @@ describe('abi validation routing', () => {
   const validB32 = abiBytes32.encode(b32)
   const invalidB32 = abiBytes32.encode(b32).slice(0, -1)
 
-  const test = createArc4TestFixture('tests/approvals/abi-validation.algo.ts', { AbiValidationAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/abi-validation.algo.ts', contracts: { AbiValidationAlgo: {} } })
   test('with validation fails on invalid', async ({ appClientAbiValidationAlgo }) => {
     const withValidation = algosdk.ABIMethod.fromSignature('withValidation(byte[32])uint64')
 

--- a/tests/onchain/accounts.spec.ts
+++ b/tests/onchain/accounts.spec.ts
@@ -3,7 +3,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('accounts', () => {
-  const test = createArc4TestFixture('tests/approvals/accounts.algo.ts', { AccountsContract: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/accounts.algo.ts', contracts: { AccountsContract: {} } })
 
   test('returns account data', async ({ appClientAccountsContract: appClient, expect, assetFactory, testAccount }) => {
     const asset = await assetFactory({ assetName: 'Asset 1', sender: testAccount.addr, total: 1n })

--- a/tests/onchain/arc-28-events.spec.ts
+++ b/tests/onchain/arc-28-events.spec.ts
@@ -3,7 +3,7 @@ import { uint8ArrayToHex, utf8ToUint8Array } from '../../src/util'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('arc 28 events', () => {
-  const test = createArc4TestFixture('tests/approvals/arc-28-events.algo.ts', { EventEmitter: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/arc-28-events.algo.ts', contracts: { EventEmitter: {} } })
 
   test('It works with struct types', async ({ appClientEventEmitter, expect }) => {
     const result = await appClientEventEmitter.send.call({ method: 'emitSwapped', args: [0, 255] })

--- a/tests/onchain/arc4-bool.spec.ts
+++ b/tests/onchain/arc4-bool.spec.ts
@@ -2,8 +2,11 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('arc4 bool', () => {
-  const test = createArc4TestFixture('tests/approvals/arc4-bool.algo.ts', {
-    Arc4BoolAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/arc4-bool.algo.ts',
+    contracts: {
+      Arc4BoolAlgo: {},
+    },
   })
 
   test('it packs correctly', async ({ appClientArc4BoolAlgo }) => {

--- a/tests/onchain/arc4-hybrid.spec.ts
+++ b/tests/onchain/arc4-hybrid.spec.ts
@@ -3,7 +3,7 @@ import { uint8ArrayToUtf8 } from '../../src/util'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('arc4-hybrid', () => {
-  const test = createArc4TestFixture('tests/approvals/arc4-hybrid.algo.ts', { Arc4HybridAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/arc4-hybrid.algo.ts', contracts: { Arc4HybridAlgo: {} } })
   test('works as expected', async ({ appClientArc4HybridAlgo, expect }) => {
     const result = await appClientArc4HybridAlgo.send.call({ method: 'someMethod' })
     const logs = result.confirmation.logs!.map(uint8ArrayToUtf8)

--- a/tests/onchain/arc4-method-selector.spec.ts
+++ b/tests/onchain/arc4-method-selector.spec.ts
@@ -2,7 +2,10 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('arc4 method selector', () => {
-  const test = createArc4TestFixture('tests/approvals/arc4-method-selector.algo.ts', { ContractOne: {}, ContractTwo: {} })
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/arc4-method-selector.algo.ts',
+    contracts: { ContractOne: {}, ContractTwo: {} },
+  })
 
   test('It gets the correct method selector', async ({ appClientContractTwo, expect }) => {
     const result = await appClientContractTwo.send.call({ method: 'test', args: [] })

--- a/tests/onchain/arc4-types.spec.ts
+++ b/tests/onchain/arc4-types.spec.ts
@@ -4,7 +4,7 @@ import { bigIntToUint8Array, utf8ToUint8Array } from '../../src/util'
 import { createArc4TestFixture, createBaseTestFixture } from './util/test-fixture'
 
 describe('arc4-types', () => {
-  const test = createBaseTestFixture('tests/approvals/arc4-types.algo.ts', ['Arc4TypesTestContract'])
+  const test = createBaseTestFixture({ path: 'tests/approvals/arc4-types.algo.ts', contracts: ['Arc4TypesTestContract'] })
 
   test('runs', async ({ Arc4TypesTestContractInvoker }) => {
     await Arc4TypesTestContractInvoker.send({ extraFee: algos(1) })
@@ -12,7 +12,7 @@ describe('arc4-types', () => {
 })
 
 describe('arc4-struct', () => {
-  const test = createArc4TestFixture('tests/approvals/arc4-struct.algo.ts', { StructDemo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/arc4-struct.algo.ts', contracts: { StructDemo: {} } })
 
   test('testVectorCreationAndEquality', async ({ appClientStructDemo }) => {
     await appClientStructDemo.send.call({ method: 'testVectorCreationAndEquality' })
@@ -39,7 +39,7 @@ describe('arc4-struct', () => {
   })
 })
 describe('arc4-encode-decode', () => {
-  const test = createArc4TestFixture('tests/approvals/arc4-encode-decode.algo.ts', { Arc4EncodeDecode: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/arc4-encode-decode.algo.ts', contracts: { Arc4EncodeDecode: {} } })
   test('encoding', async ({ appClientArc4EncodeDecode, testAccount }) => {
     await appClientArc4EncodeDecode.send.call({
       method: 'testEncoding',

--- a/tests/onchain/array-destructuring.spec.ts
+++ b/tests/onchain/array-destructuring.spec.ts
@@ -2,8 +2,11 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('array destructuring', () => {
-  const test = createArc4TestFixture('tests/approvals/array-destructuring.algo.ts', {
-    ArrayDestructuringAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/array-destructuring.algo.ts',
+    contracts: {
+      ArrayDestructuringAlgo: {},
+    },
   })
 
   test('testNested', async ({ appClientArrayDestructuringAlgo }) => {

--- a/tests/onchain/array-literals.spec.ts
+++ b/tests/onchain/array-literals.spec.ts
@@ -2,8 +2,11 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('array literals', () => {
-  const test = createArc4TestFixture('tests/approvals/array-literals.algo.ts', {
-    ArrayLiteralsAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/array-literals.algo.ts',
+    contracts: {
+      ArrayLiteralsAlgo: {},
+    },
   })
 
   test('test', async ({ appClientArrayLiteralsAlgo }) => {

--- a/tests/onchain/assert-match.spec.ts
+++ b/tests/onchain/assert-match.spec.ts
@@ -3,7 +3,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('assert match', () => {
-  const test = createArc4TestFixture('tests/approvals/assert-match.algo.ts', { AssertMatchContract: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/assert-match.algo.ts', contracts: { AssertMatchContract: {} } })
 
   test('it can be called', async ({ appClientAssertMatchContract, algorand, testAccount }) => {
     const payment = algorand.createTransaction.payment({

--- a/tests/onchain/asset-proxy.spec.ts
+++ b/tests/onchain/asset-proxy.spec.ts
@@ -3,8 +3,11 @@ import { invariant, uint8ArrayToBase32, uint8ArrayToBigInt, uint8ArrayToHex, uin
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('asset proxy contract', () => {
-  const test = createArc4TestFixture('tests/approvals/asset-proxy.algo.ts', {
-    AssetProxyAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/asset-proxy.algo.ts',
+    contracts: {
+      AssetProxyAlgo: {},
+    },
   })
   test('it runs', async ({ appClientAssetProxyAlgo, assetFactory, testAccount, expect }) => {
     const mdh = new Uint8Array(32)

--- a/tests/onchain/assignments.spec.ts
+++ b/tests/onchain/assignments.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('assignments', () => {
-  const test = createArc4TestFixture('tests/approvals/assignments.algo.ts', { AssignmentsAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/assignments.algo.ts', contracts: { AssignmentsAlgo: {} } })
 
   test('testPrimitives', async ({ appClientAssignmentsAlgo }) => {
     await appClientAssignmentsAlgo.send.call({ method: 'testPrimitives', args: [123] })

--- a/tests/onchain/avm12.spec.ts
+++ b/tests/onchain/avm12.spec.ts
@@ -3,7 +3,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('avm12', () => {
-  const test = createArc4TestFixture('tests/approvals/avm12.algo.ts', { Avm12Contract: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/avm12.algo.ts', contracts: { Avm12Contract: {} } })
 
   test('reject wrong app version', async ({ appClientAvm12Contract }) => {
     await appClientAvm12Contract.fundAppAccount({ amount: algos(1) })

--- a/tests/onchain/box-enum-contract.spec.ts
+++ b/tests/onchain/box-enum-contract.spec.ts
@@ -3,7 +3,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('box-enum-contract', () => {
-  const test = createArc4TestFixture('tests/approvals/box-enum-contract.algo.ts', { BoxContract: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/box-enum-contract.algo.ts', contracts: { BoxContract: {} } })
 
   test('can store and load enums', async ({ appClientBoxContract, expect }) => {
     await appClientBoxContract.fundAppAccount({ amount: algo(1) })

--- a/tests/onchain/box-proxies.spec.ts
+++ b/tests/onchain/box-proxies.spec.ts
@@ -5,7 +5,7 @@ import { bigIntToUint8Array, invariant, uint8ArrayToUtf8, utf8ToUint8Array } fro
 import { createArc4TestFixture, createBaseTestFixture } from './util/test-fixture'
 
 describe('BoxProxies', () => {
-  const test = createBaseTestFixture('tests/approvals/box-proxies.algo.ts', ['BoxContract', 'BoxNotExist', 'LargeBox'])
+  const test = createBaseTestFixture({ path: 'tests/approvals/box-proxies.algo.ts', contracts: ['BoxContract', 'BoxNotExist', 'LargeBox'] })
 
   test('Should run', async ({ BoxContractInvoker, algorand, testAccount }) => {
     const created = await BoxContractInvoker.send()
@@ -72,12 +72,15 @@ describe('BoxProxies', () => {
     })
   })
 
-  const it = createArc4TestFixture('tests/approvals/box-proxies.algo.ts', {
-    BoxCreate: { funding: algos(1) },
-    Arc4BoxContract: { funding: algos(10) },
-    TupleBox: { funding: algos(1) },
-    BoxToRefTest: { funding: algos(1) },
-    CompositeKeyTest: { funding: algos(1) },
+  const it = createArc4TestFixture({
+    path: 'tests/approvals/box-proxies.algo.ts',
+    contracts: {
+      BoxCreate: { funding: algos(1) },
+      Arc4BoxContract: { funding: algos(10) },
+      TupleBox: { funding: algos(1) },
+      BoxToRefTest: { funding: algos(1) },
+      CompositeKeyTest: { funding: algos(1) },
+    },
   })
   it('creates boxes of the min size', async ({ appClientBoxCreate }) => {
     await appClientBoxCreate.send.call({ method: 'createBoxes', boxReferences: ['bool', 'arc4b', 'a', 'b', 'c', 'd', 'e'] })
@@ -293,7 +296,7 @@ describe('BoxProxies', () => {
 const APPROVE = new Uint8Array([0x09, 0x81, 0x01])
 
 describe('LargeBox', () => {
-  const test = createArc4TestFixture('tests/approvals/box-proxies.algo.ts', { LargeBox: { funding: algos(6) } })
+  const test = createArc4TestFixture({ path: 'tests/approvals/box-proxies.algo.ts', contracts: { LargeBox: { funding: algos(6) } } })
 
   test('should work with large boxes', async ({ appClientLargeBox, algorand, testAccount }) => {
     const call = await appClientLargeBox.createTransaction.call({

--- a/tests/onchain/byte-expressions.spec.ts
+++ b/tests/onchain/byte-expressions.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('byte expressions', () => {
-  const test = createArc4TestFixture('tests/approvals/byte-expressions.algo.ts', { DemoContract: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/byte-expressions.algo.ts', contracts: { DemoContract: {} } })
 
   test('runs', async ({ appClientDemoContract }) => {
     await appClientDemoContract.send.call({ method: 'test' })

--- a/tests/onchain/const-literals.spec.ts
+++ b/tests/onchain/const-literals.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('const literals', () => {
-  const test = createArc4TestFixture('tests/approvals/const-literals.algo.ts', { ConstLiteralsAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/const-literals.algo.ts', contracts: { ConstLiteralsAlgo: {} } })
   test('runs', async ({ appClientConstLiteralsAlgo }) => {
     const res1 = await appClientConstLiteralsAlgo.send.call({ method: 'test' })
     expect(res1.return).toBe(123n)

--- a/tests/onchain/destructured-params.spec.ts
+++ b/tests/onchain/destructured-params.spec.ts
@@ -3,8 +3,11 @@ import { bigIntToUint8Array, hexToUint8Array, joinUint8Arrays, utf8ToUint8Array 
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('destructed params', () => {
-  const test = createArc4TestFixture('tests/approvals/destructured-params.algo.ts', {
-    DestructuredParamsAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/destructured-params.algo.ts',
+    contracts: {
+      DestructuredParamsAlgo: {},
+    },
   })
   test('Works from abi', async ({ appClientDestructuredParamsAlgo }) => {
     const result = await appClientDestructuredParamsAlgo.send.call({ method: 'test', args: [{ a: 1, b: hexToUint8Array('FF'), c: true }] })

--- a/tests/onchain/destructuring.spec.ts
+++ b/tests/onchain/destructuring.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('destructuring iterators', () => {
-  const test = createArc4TestFixture('tests/approvals/destructuring-iterators.algo.ts', { DestructuringIterators: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/destructuring-iterators.algo.ts', contracts: { DestructuringIterators: {} } })
 
   test('runs', async ({ appClientDestructuringIterators }) => {
     await appClientDestructuringIterators.send.call({ method: 'test' })

--- a/tests/onchain/do-loops.spec.ts
+++ b/tests/onchain/do-loops.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('do loops', () => {
-  const test = createArc4TestFixture('tests/approvals/do-loops.algo.ts', { DoLoopsAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/do-loops.algo.ts', contracts: { DoLoopsAlgo: {} } })
 
   test('testDo runs', async ({ appClientDoLoopsAlgo, expect }) => {
     const result = await appClientDoLoopsAlgo.send.call({ method: 'testDo', args: [10] })

--- a/tests/onchain/extract-bytes.spec.ts
+++ b/tests/onchain/extract-bytes.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createBaseTestFixture } from './util/test-fixture'
 
 describe('Extract bytes contract', () => {
-  const test = createBaseTestFixture('tests/approvals/extract-bytes.algo.ts', ['ExtractBytesAlgo'])
+  const test = createBaseTestFixture({ path: 'tests/approvals/extract-bytes.algo.ts', contracts: ['ExtractBytesAlgo'] })
 
   test('runs', async ({ ExtractBytesAlgoInvoker }) => {
     await ExtractBytesAlgoInvoker.send()

--- a/tests/onchain/for-loops.spec.ts
+++ b/tests/onchain/for-loops.spec.ts
@@ -2,8 +2,11 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('for loops', () => {
-  const test = createArc4TestFixture('tests/approvals/for-loops.algo.ts', {
-    ForLoopsAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/for-loops.algo.ts',
+    contracts: {
+      ForLoopsAlgo: {},
+    },
   })
 
   test('basic', async ({ appClientForLoopsAlgo }) => {

--- a/tests/onchain/for-of-loops.spec.ts
+++ b/tests/onchain/for-of-loops.spec.ts
@@ -2,8 +2,11 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('for loops', () => {
-  const test = createArc4TestFixture('tests/approvals/for-of-loops.algo.ts', {
-    ForOfLoopsAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/for-of-loops.algo.ts',
+    contracts: {
+      ForOfLoopsAlgo: {},
+    },
   })
 
   test('test_for_of_loop_tuple', async ({ appClientForOfLoopsAlgo }) => {

--- a/tests/onchain/global-state.spec.ts
+++ b/tests/onchain/global-state.spec.ts
@@ -3,7 +3,7 @@ import { bigIntToUint8Array, invariant } from '../../src/util'
 import { createArc4TestFixture, createBaseTestFixture } from './util/test-fixture'
 
 describe('global state base', () => {
-  const test = createBaseTestFixture('tests/approvals/global-state.algo.ts', ['TestContract'])
+  const test = createBaseTestFixture({ path: 'tests/approvals/global-state.algo.ts', contracts: ['TestContract'] })
 
   test('test runs', async ({ TestContractInvoker, expect }) => {
     const result = await TestContractInvoker.send({
@@ -25,7 +25,7 @@ describe('global state base', () => {
   })
 })
 describe('global state arc4', () => {
-  const test = createArc4TestFixture('tests/approvals/global-state.algo.ts', { TestArc4: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/global-state.algo.ts', contracts: { TestArc4: {} } })
 
   test('arc4 runs', async ({ appClientTestArc4, expect }) => {
     await appClientTestArc4.send.call({ method: 'setState', args: ['key1', 123] })
@@ -51,7 +51,7 @@ describe('global state arc4', () => {
 })
 
 describe('global state tuple', () => {
-  const test = createArc4TestFixture('tests/approvals/global-state.algo.ts', { TestTuple: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/global-state.algo.ts', contracts: { TestTuple: {} } })
 
   test('tuple runs', async ({ appClientTestTuple }) => {
     await appClientTestTuple.send.call({ method: 'testTuple' })

--- a/tests/onchain/gtxns.spec.ts
+++ b/tests/onchain/gtxns.spec.ts
@@ -4,7 +4,7 @@ import { bigIntToUint8Array } from '../../src/util'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('gtxns contract', () => {
-  const test = createArc4TestFixture('tests/approvals/gtxns.algo.ts', { GtxnsAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/gtxns.algo.ts', contracts: { GtxnsAlgo: {} } })
   test('it verifies the txn type', async ({ appClientGtxnsAlgo, algorand, testAccount }) => {
     const call = await appClientGtxnsAlgo.createTransaction.call({ method: 'test', args: [] })
 

--- a/tests/onchain/implicit-create.spec.ts
+++ b/tests/onchain/implicit-create.spec.ts
@@ -2,11 +2,14 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('implicit-create', () => {
-  const test = createArc4TestFixture('tests/approvals/implicit-create.algo.ts', {
-    NoBare: {},
-    NoNoOp: {},
-    ExplicitBareCreateFromBase: {},
-    ExplicitAbiCreateFromBase: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/implicit-create.algo.ts',
+    contracts: {
+      NoBare: {},
+      NoNoOp: {},
+      ExplicitBareCreateFromBase: {},
+      ExplicitAbiCreateFromBase: {},
+    },
   })
   test('NoBare can be created', async ({ appFactoryNoBare }) => {
     await appFactoryNoBare.send.bare.create()

--- a/tests/onchain/inheritance.spec.ts
+++ b/tests/onchain/inheritance.spec.ts
@@ -5,7 +5,7 @@ import { createArc4TestFixture, createBaseTestFixture } from './util/test-fixtur
 
 describe('inheritance', () => {
   describe('non arc4', () => {
-    const test = createBaseTestFixture('tests/approvals/inheritance-b.algo.ts', ['ConcreteSimpleContract'])
+    const test = createBaseTestFixture({ path: 'tests/approvals/inheritance-b.algo.ts', contracts: ['ConcreteSimpleContract'] })
     test('Simple contract can be created', async ({ ConcreteSimpleContractInvoker, expect }) => {
       const result = await ConcreteSimpleContractInvoker.send({
         args: [bigIntToUint8Array(10n), bigIntToUint8Array(2n)],
@@ -16,7 +16,7 @@ describe('inheritance', () => {
     })
   })
   describe('arc4', () => {
-    const test = createArc4TestFixture('tests/approvals/inheritance-b.algo.ts', { ConcreteArc4Contract: {} })
+    const test = createArc4TestFixture({ path: 'tests/approvals/inheritance-b.algo.ts', contracts: { ConcreteArc4Contract: {} } })
     test('ARC4 contract can be created', async ({ appFactoryConcreteArc4Contract }) => {
       await appFactoryConcreteArc4Contract.send.bare.create()
     })

--- a/tests/onchain/itxn-compose.spec.ts
+++ b/tests/onchain/itxn-compose.spec.ts
@@ -3,9 +3,12 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('itxn compose', () => {
-  const test = createArc4TestFixture('tests/approvals/itxn-compose.algo.ts', {
-    ItxnComposeAlgo: { funding: algos(5) },
-    VerifierContract: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/itxn-compose.algo.ts',
+    contracts: {
+      ItxnComposeAlgo: { funding: algos(5) },
+      VerifierContract: {},
+    },
   })
 
   test('it can be called', async ({ localnet, algorand, appClientVerifierContract, appClientItxnComposeAlgo, testAccount }) => {

--- a/tests/onchain/itxn.spec.ts
+++ b/tests/onchain/itxn.spec.ts
@@ -3,9 +3,12 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('itxn contract', () => {
-  const test = createArc4TestFixture('tests/approvals/itxn.algo.ts', {
-    ItxnDemoContract: { funding: algos(2) },
-    ItxnReceiver: { funding: algos(1) },
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/itxn.algo.ts',
+    contracts: {
+      ItxnDemoContract: { funding: algos(2) },
+      ItxnReceiver: { funding: algos(1) },
+    },
   })
 
   test('test1 runs', async ({ appClientItxnDemoContract }) => {

--- a/tests/onchain/large-objects-in-state.spec.ts
+++ b/tests/onchain/large-objects-in-state.spec.ts
@@ -4,7 +4,7 @@ import { invariant } from '../../src/util'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('large-objects-in-state', () => {
-  const test = createArc4TestFixture('tests/approvals/large-objects-in-state.algo.ts', { LargeObjectsInStateAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/large-objects-in-state.algo.ts', contracts: { LargeObjectsInStateAlgo: {} } })
 
   test('it runs', async ({ appFactoryLargeObjectsInStateAlgo, algorand, testAccount }) => {
     const { appClient } = await appFactoryLargeObjectsInStateAlgo.send.bare.create({})

--- a/tests/onchain/local-state.spec.ts
+++ b/tests/onchain/local-state.spec.ts
@@ -3,7 +3,11 @@ import { utf8ToUint8Array } from '../../src/util'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('local state', () => {
-  const test = createArc4TestFixture('tests/approvals/local-state.algo.ts', { LocalStateDemo: {} }, beforeEach)
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/local-state.algo.ts',
+    contracts: { LocalStateDemo: {} },
+    newScopeAt: beforeEach,
+  })
 
   test('it runs', async ({ appClientLocalStateDemo, appFactoryLocalStateDemo }) => {
     const testArray = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/tests/onchain/match-expr.spec.ts
+++ b/tests/onchain/match-expr.spec.ts
@@ -2,8 +2,11 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('match expr', () => {
-  const test = createArc4TestFixture('tests/approvals/match-expr.algo.ts', {
-    MatchExprAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/match-expr.algo.ts',
+    contracts: {
+      MatchExprAlgo: {},
+    },
   })
   test('it runs', async ({ appClientMatchExprAlgo }) => {
     await appClientMatchExprAlgo.send.call({ method: 'testMatches', args: [5] })

--- a/tests/onchain/module-constants.spec.ts
+++ b/tests/onchain/module-constants.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('module constants', () => {
-  const test = createArc4TestFixture('tests/approvals/module-constants.algo.ts', { ModuleConstantsAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/module-constants.algo.ts', contracts: { ModuleConstantsAlgo: {} } })
 
   test('bool constants work', async ({ appClientModuleConstantsAlgo }) => {
     const result = await appClientModuleConstantsAlgo.send.call({ method: 'getBoolConstants' })

--- a/tests/onchain/multi-inheritance.spec.ts
+++ b/tests/onchain/multi-inheritance.spec.ts
@@ -2,11 +2,14 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('multi-inheritance', () => {
-  const test = createArc4TestFixture('tests/approvals/multi-inheritance.algo.ts', {
-    CommonBase: {},
-    BaseOne: {},
-    BaseTwo: {},
-    MultiBases: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/multi-inheritance.algo.ts',
+    contracts: {
+      CommonBase: {},
+      BaseOne: {},
+      BaseTwo: {},
+      MultiBases: {},
+    },
   })
 
   test('CommonBase has all state', async ({ appClientCommonBase, expect }) => {
@@ -64,8 +67,11 @@ describe('multi-inheritance', () => {
 })
 
 describe('multi-inheritance 2', () => {
-  const test = createArc4TestFixture('tests/approvals/multi-inheritance-2.algo.ts', {
-    StoreBoth: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/multi-inheritance-2.algo.ts',
+    contracts: {
+      StoreBoth: {},
+    },
   })
 
   test('Both base functions can be resolved', async ({ appClientStoreBoth }) => {

--- a/tests/onchain/mutable-object.spec.ts
+++ b/tests/onchain/mutable-object.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('mutable-object', () => {
-  const test = createArc4TestFixture('tests/approvals/mutable-object.algo.ts', { MutableObjectDemo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/mutable-object.algo.ts', contracts: { MutableObjectDemo: {} } })
 
   test('testVectorCreationAndEquality', async ({ appClientMutableObjectDemo }) => {
     await appClientMutableObjectDemo.send.call({ method: 'testVectorCreationAndEquality' })

--- a/tests/onchain/native-arrays.spec.ts
+++ b/tests/onchain/native-arrays.spec.ts
@@ -3,8 +3,11 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('native arrays', () => {
-  const test = createArc4TestFixture('tests/approvals/native-arrays.algo.ts', {
-    NativeArraysAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/native-arrays.algo.ts',
+    contracts: {
+      NativeArraysAlgo: {},
+    },
   })
   test('it runs', async ({ appClientNativeArraysAlgo }) => {
     await appClientNativeArraysAlgo.send.call({ method: 'doThings', args: [], extraFee: algos(1) })

--- a/tests/onchain/object-destructuring.spec.ts
+++ b/tests/onchain/object-destructuring.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('object destructuring', () => {
-  const test = createArc4TestFixture('tests/approvals/object-destructuring.algo.ts', { ObjectDestructuringAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/object-destructuring.algo.ts', contracts: { ObjectDestructuringAlgo: {} } })
   test('it runs', async ({ appClientObjectDestructuringAlgo }) => {
     await appClientObjectDestructuringAlgo.send.call({ method: 'test' })
   })

--- a/tests/onchain/ops.spec.ts
+++ b/tests/onchain/ops.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('ops', () => {
-  const test = createArc4TestFixture('tests/approvals/ops.algo.ts', { MyContract: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/ops.algo.ts', contracts: { MyContract: {} } })
 
   test('runs', async ({ appClientMyContract }) => {
     await appClientMyContract.send.call({ method: 'test' })

--- a/tests/onchain/precompiled.spec.ts
+++ b/tests/onchain/precompiled.spec.ts
@@ -4,7 +4,7 @@ import { createArc4TestFixture } from './util/test-fixture'
 
 describe('precompiled', () => {
   describe('un-typed', () => {
-    const test = createArc4TestFixture('tests/approvals/precompiled-factory.algo.ts', { HelloFactory: {} })
+    const test = createArc4TestFixture({ path: 'tests/approvals/precompiled-factory.algo.ts', contracts: { HelloFactory: {} } })
 
     test('Hello contract can be deployed', async ({ appClientHelloFactory }) => {
       await appClientHelloFactory.send.call({ method: 'test_compile_contract', extraFee: algo(1) })
@@ -20,7 +20,10 @@ describe('precompiled', () => {
     })
   })
   describe('typed', () => {
-    const test = createArc4TestFixture('tests/approvals/precompiled-typed.algo.ts', { HelloFactory: { funding: algo(1) } })
+    const test = createArc4TestFixture({
+      path: 'tests/approvals/precompiled-typed.algo.ts',
+      contracts: { HelloFactory: { funding: algo(1) } },
+    })
 
     test('Hello contract can be deployed', async ({ appClientHelloFactory }) => {
       await appClientHelloFactory.send.call({ method: 'test_compile_contract', extraFee: algo(1) })

--- a/tests/onchain/prefix-postfix-operators.spec.ts
+++ b/tests/onchain/prefix-postfix-operators.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('prefix postfix operators', () => {
-  const test = createArc4TestFixture('tests/approvals/prefix-postfix-operators.algo.ts', ['DemoContract'])
+  const test = createArc4TestFixture({ path: 'tests/approvals/prefix-postfix-operators.algo.ts', contracts: ['DemoContract'] })
 
   test('it runs', async ({ appClientDemoContract }) => {
     await appClientDemoContract.send.call({ method: 'test' })

--- a/tests/onchain/primitives.spec.ts
+++ b/tests/onchain/primitives.spec.ts
@@ -3,7 +3,7 @@ import { createArc4TestFixture, createBaseTestFixture } from './util/test-fixtur
 
 describe('primitives', () => {
   describe('boolean', () => {
-    const test = createBaseTestFixture('tests/approvals/boolean-conversions.algo.ts', ['BooleanConversionsAlgo'])
+    const test = createBaseTestFixture({ path: 'tests/approvals/boolean-conversions.algo.ts', contracts: ['BooleanConversionsAlgo'] })
 
     test('it can be called', async ({ BooleanConversionsAlgoInvoker }) => {
       await BooleanConversionsAlgoInvoker.send()
@@ -11,26 +11,26 @@ describe('primitives', () => {
   })
 
   describe('uint64', () => {
-    const test = createBaseTestFixture('tests/approvals/uint64-expressions.algo.ts', ['DemoContract'])
+    const test = createBaseTestFixture({ path: 'tests/approvals/uint64-expressions.algo.ts', contracts: ['DemoContract'] })
     test('can be created', async ({ DemoContractInvoker }) => {
       await DemoContractInvoker.send()
     })
   })
   describe('biguint', () => {
-    const test = createBaseTestFixture('tests/approvals/biguint-expressions.algo.ts', ['DemoContract'])
+    const test = createBaseTestFixture({ path: 'tests/approvals/biguint-expressions.algo.ts', contracts: ['DemoContract'] })
     test('can be created', async ({ DemoContractInvoker }) => {
       await DemoContractInvoker.send()
     })
   })
   describe('bytes', () => {
-    const test = createBaseTestFixture('tests/approvals/byte-expressions.algo.ts', ['DemoContract'])
+    const test = createBaseTestFixture({ path: 'tests/approvals/byte-expressions.algo.ts', contracts: ['DemoContract'] })
     test('can be created', async ({ DemoContractInvoker }) => {
       await DemoContractInvoker.send()
     })
   })
 
   describe('strings', () => {
-    const test = createArc4TestFixture('tests/approvals/strings.algo.ts', { StringContract: {} })
+    const test = createArc4TestFixture({ path: 'tests/approvals/strings.algo.ts', contracts: { StringContract: {} } })
 
     test('can be joined', async ({ appClientStringContract, expect }) => {
       const result = await appClientStringContract.send.call({ method: 'join', args: ['hello', 'world'] })

--- a/tests/onchain/property-ordering.spec.ts
+++ b/tests/onchain/property-ordering.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createBaseTestFixture } from './util/test-fixture'
 
 describe('Property ordering', () => {
-  const test = createBaseTestFixture('tests/approvals/property-ordering.algo.ts', ['Demo'])
+  const test = createBaseTestFixture({ path: 'tests/approvals/property-ordering.algo.ts', contracts: ['Demo'] })
 
   test('it runs ', async ({ DemoInvoker }) => {
     await DemoInvoker.send()

--- a/tests/onchain/reference-arrays.spec.ts
+++ b/tests/onchain/reference-arrays.spec.ts
@@ -3,8 +3,11 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('reference arrays', () => {
-  const test = createArc4TestFixture('tests/approvals/reference-arrays.algo.ts', {
-    ReferenceArraysAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/reference-arrays.algo.ts',
+    contracts: {
+      ReferenceArraysAlgo: {},
+    },
   })
   test('it runs', async ({ appClientReferenceArraysAlgo }) => {
     await appClientReferenceArraysAlgo.send.call({ method: 'test', args: [5], extraFee: algos(1) })

--- a/tests/onchain/reserve-scratch.spec.ts
+++ b/tests/onchain/reserve-scratch.spec.ts
@@ -2,7 +2,10 @@ import { describe } from 'vitest'
 import { createBaseTestFixture } from './util/test-fixture'
 
 describe('reserve scratch', () => {
-  const test = createBaseTestFixture('tests/approvals/reserve-scratch.algo.ts', ['ReserveScratchAlgo', 'SubReserveScratchAlgo'])
+  const test = createBaseTestFixture({
+    path: 'tests/approvals/reserve-scratch.algo.ts',
+    contracts: ['ReserveScratchAlgo', 'SubReserveScratchAlgo'],
+  })
 
   test('ReserveScratchAlgo works', async ({ ReserveScratchAlgoInvoker }) => {
     await ReserveScratchAlgoInvoker.send()

--- a/tests/onchain/resource-encoding.spec.ts
+++ b/tests/onchain/resource-encoding.spec.ts
@@ -3,10 +3,13 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('resource encoding', () => {
-  const test = createArc4TestFixture('tests/approvals/resource-encoding.algo.ts', {
-    ByIndex: {},
-    ByValue: {},
-    C2C: { funding: algo(1) },
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/resource-encoding.algo.ts',
+    contracts: {
+      ByIndex: {},
+      ByValue: {},
+      C2C: { funding: algo(1) },
+    },
   })
 
   test('index', async ({ appClientByIndex, localnet }) => {

--- a/tests/onchain/shadowed-variables.spec.ts
+++ b/tests/onchain/shadowed-variables.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createBaseTestFixture } from './util/test-fixture'
 
 describe('Shadowed variables', () => {
-  const test = createBaseTestFixture('tests/approvals/shadowed-variables.algo.ts', ['ShadowedVariablesAlgo'])
+  const test = createBaseTestFixture({ path: 'tests/approvals/shadowed-variables.algo.ts', contracts: ['ShadowedVariablesAlgo'] })
 
   test('Should create and run', async ({ ShadowedVariablesAlgoInvoker }) => {
     await ShadowedVariablesAlgoInvoker.send()

--- a/tests/onchain/single-eval.spec.ts
+++ b/tests/onchain/single-eval.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('single-eval', () => {
-  const test = createArc4TestFixture('tests/approvals/single-eval.algo.ts', { SingleEvalAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/single-eval.algo.ts', contracts: { SingleEvalAlgo: {} } })
 
   test('Works as expected', async ({ appClientSingleEvalAlgo }) => {
     await appClientSingleEvalAlgo.send.call({ method: 'test' })

--- a/tests/onchain/state-totals.spec.ts
+++ b/tests/onchain/state-totals.spec.ts
@@ -3,11 +3,14 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('State totals', () => {
-  const test = createArc4TestFixture('tests/approvals/state-totals.algo.ts', {
-    ExtendsSubWithTotals: {},
-    BaseWithState: {},
-    SubClassWithState: {},
-    SubClassWithExplicitTotals: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/state-totals.algo.ts',
+    contracts: {
+      ExtendsSubWithTotals: {},
+      BaseWithState: {},
+      SubClassWithState: {},
+      SubClassWithExplicitTotals: {},
+    },
   })
 
   test('BaseWithState has correct totals', ({ appSpecBaseWithState }) => {

--- a/tests/onchain/static-bytes.spec.ts
+++ b/tests/onchain/static-bytes.spec.ts
@@ -3,8 +3,11 @@ import { invariant } from '../../src/util'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('static bytes', () => {
-  const test = createArc4TestFixture('tests/approvals/static-bytes.algo.ts', {
-    StaticBytesAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/static-bytes.algo.ts',
+    contracts: {
+      StaticBytesAlgo: {},
+    },
   })
   test('it works as abi parameter and return type', async ({ appClientStaticBytesAlgo, testAccount }) => {
     const result = await appClientStaticBytesAlgo.send.call({ method: 'receiveB32', args: [testAccount.addr.publicKey] })

--- a/tests/onchain/super-calls.spec.ts
+++ b/tests/onchain/super-calls.spec.ts
@@ -2,12 +2,10 @@ import { describe } from 'vitest'
 import { createBaseTestFixture } from './util/test-fixture'
 
 describe('super calls', () => {
-  const test = createBaseTestFixture('tests/approvals/super-calls.algo.ts', [
-    'SuperContract',
-    'SubContract',
-    'SubSubContract',
-    'SubSubSubContract',
-  ])
+  const test = createBaseTestFixture({
+    path: 'tests/approvals/super-calls.algo.ts',
+    contracts: ['SuperContract', 'SubContract', 'SubSubContract', 'SubSubSubContract'],
+  })
 
   test('super contract runs', async ({ SuperContractInvoker }) => {
     await SuperContractInvoker.send({ schema: { globalInts: 1 } })

--- a/tests/onchain/switch-statements.spec.ts
+++ b/tests/onchain/switch-statements.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('switch statements', () => {
-  const test = createArc4TestFixture('tests/approvals/switch-statements.algo.ts', { DemoContract: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/switch-statements.algo.ts', contracts: { DemoContract: {} } })
 
   test('runs', async ({ appClientDemoContract }) => {
     await appClientDemoContract.send.call({ method: 'run', args: [] })

--- a/tests/onchain/teal-script-conventions.spec.ts
+++ b/tests/onchain/teal-script-conventions.spec.ts
@@ -4,8 +4,11 @@ import { utf8ToUint8Array } from '../../src/util'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('teal-script conventions', () => {
-  const test = createArc4TestFixture('tests/approvals/teal-script-conventions.algo.ts', {
-    TealScriptConventionsAlgo: {},
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/teal-script-conventions.algo.ts',
+    contracts: {
+      TealScriptConventionsAlgo: {},
+    },
   })
 
   test('lifecycle methods are routed as expected', async ({ appFactoryTealScriptConventionsAlgo, testAccount }) => {

--- a/tests/onchain/template-vars.spec.ts
+++ b/tests/onchain/template-vars.spec.ts
@@ -12,10 +12,13 @@ describe('template var', () => {
     SOME_BYTES: hexToUint8Array('FF0044'),
     AN_ADDRESS: address.publicKey,
   }
-  const test = createArc4TestFixture('tests/approvals/template-var.algo.ts', {
-    MyContract: {
-      deployParams: {
-        deployTimeParams: templateVars,
+  const test = createArc4TestFixture({
+    path: 'tests/approvals/template-var.algo.ts',
+    contracts: {
+      MyContract: {
+        deployParams: {
+          deployTimeParams: templateVars,
+        },
       },
     },
   })

--- a/tests/onchain/uint64-to-string.spec.ts
+++ b/tests/onchain/uint64-to-string.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('uint64-to-string', () => {
-  const test = createArc4TestFixture('tests/approvals/uint64-to-string.algo.ts', { Uint64ToStringAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/uint64-to-string.algo.ts', contracts: { Uint64ToStringAlgo: {} } })
 
   test('it works', async ({ appClientUint64ToStringAlgo }) => {
     const { return: result } = await appClientUint64ToStringAlgo.send.call({ method: 'test', args: [456] })

--- a/tests/onchain/urange.spec.ts
+++ b/tests/onchain/urange.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('urange', () => {
-  const test = createArc4TestFixture('tests/approvals/urange.algo.ts', { UrangeAlgo: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/urange.algo.ts', contracts: { UrangeAlgo: {} } })
 
   test('works with single arg', async ({ appClientUrangeAlgo }) => {
     const result = await appClientUrangeAlgo.send.call({ method: 'testSingleArg' })

--- a/tests/onchain/util/test-fixture.ts
+++ b/tests/onchain/util/test-fixture.ts
@@ -88,11 +88,22 @@ type ProgramInvoker = {
 type BaseFixtureContextFor<T extends string> = {
   [key in T as `${key}Invoker`]: ProgramInvoker
 }
-export function createBaseTestFixture<TContracts extends string = ''>(
-  path: string,
-  contracts: TContracts[],
-  newScopeAt: typeof beforeAll | typeof beforeEach = beforeAll,
-) {
+/**
+ * Creates a base test fixture for testing compiled Algorand smart contracts.
+ *
+ * @param options - Configuration options for the test fixture
+ * @param options.path - Path to the TypeScript file containing the contracts
+ * @param options.contracts - Array of contract names to create fixtures for
+ * @param options.newScopeAt - When to create a new test scope. Defaults to `beforeAll` for shared state across tests.
+ *                              Use `beforeEach` to create a fresh state for each test.
+ */
+export function createBaseTestFixture<TContracts extends string = ''>(options: {
+  path: string
+  contracts: TContracts[]
+  /** When to create a new test scope. Defaults to `beforeAll`. Use `beforeEach` for fresh state per test. */
+  newScopeAt?: typeof beforeAll | typeof beforeEach
+}) {
+  const { path, contracts, newScopeAt = beforeAll } = options
   const lazyCompile = createLazyCompiler(path, { outputArc56: false, outputBytecode: true })
   const localnet = algorandFixture({
     testAccountFunding: microAlgos(100_000_000_000),
@@ -164,11 +175,22 @@ type ContractConfig = {
   funding?: AlgoAmount
 }
 
-export function createArc4TestFixture<TContracts extends string = ''>(
-  path: string,
-  contracts: Record<TContracts, ContractConfig> | TContracts[],
-  newScopeAt: typeof beforeAll | typeof beforeEach = beforeAll,
-) {
+/**
+ * Creates an ARC-4 test fixture for testing Algorand ARC-4 smart contracts.
+ *
+ * @param options - Configuration options for the test fixture
+ * @param options.path - Path to the TypeScript file containing the ARC-4 contracts
+ * @param options.contracts - Contract configuration as either an array of names or pairs of name with deployment config
+ * @param options.newScopeAt - When to create a new test scope. Defaults to `beforeAll` for shared state across tests.
+ *                              Use `beforeEach` to create a fresh state for each test.
+ */
+export function createArc4TestFixture<TContracts extends string = ''>(options: {
+  path: string
+  contracts: Record<TContracts, ContractConfig> | TContracts[]
+  /** When to create a new test scope. Defaults to `beforeAll`. Use `beforeEach` for fresh state per test. */
+  newScopeAt?: typeof beforeAll | typeof beforeEach
+}) {
+  const { path, contracts, newScopeAt = beforeAll } = options
   const lazyCompile = createLazyCompiler(path, { outputArc56: true, outputBytecode: false })
   const localnet = algorandFixture({
     testAccountFunding: microAlgos(100_000_000_000),

--- a/tests/onchain/while-loops.spec.ts
+++ b/tests/onchain/while-loops.spec.ts
@@ -2,7 +2,7 @@ import { describe } from 'vitest'
 import { createArc4TestFixture } from './util/test-fixture'
 
 describe('while loops', () => {
-  const test = createArc4TestFixture('tests/approvals/while-loops.algo.ts', { DemoContract: {} })
+  const test = createArc4TestFixture({ path: 'tests/approvals/while-loops.algo.ts', contracts: { DemoContract: {} } })
 
   test('runs', async ({ appClientDemoContract, expect }) => {
     const result = await appClientDemoContract.send.call({ method: 'testWhile', args: [10] })


### PR DESCRIPTION
- `AlgorandFixture.beforeEach` has been deprecated
-  do not call `await localnetFixture.beforeEach()` in  `algorandTestFixture` method in `tests/onchain/util/test-fixture.ts`
- call `.newScope` method in `beforeAll` or `beforeEach` of each test scope before returning `AlgorandFixture`
