### PR TITLE
Add migration guides for beta and tealscript

### DIFF
--- a/docs/migration-guides.md
+++ b/docs/migration-guides.md
@@ -448,8 +448,8 @@ import { arc4 } from '@algorandfoundation/algorand-typescript'
 
 // ... rest of code
 
-const x = arc4.interpretAsArc4<Uint<32>>(a);
-const y = arc4.interpretAsArc4<Byte>(b, 'log');
+const x = arc4.interpretAsArc4<arc4.UintN<32>>(someBytes);
+const y = arc4.interpretAsArc4<arc4.Byte>(someBytes, "log");
 ```
 
 **AFTER - Algorand TypeScript 1.0**
@@ -459,8 +459,8 @@ import { arc4 } from '@algorandfoundation/algorand-typescript'
 
 // ... rest of code
 
-const x = arc4.convertBytes<arc4.Uint<32>>(a, { strategy: 'validate' });
-const y = arc4.convertBytes<arc4.Byte>(b, { prefix: 'log', strategy: 'unsafe-cast' });
+const x = arc4.convertBytes<arc4.Uint<32>>(someBytes, { strategy: 'validate' });
+const y = arc4.convertBytes<arc4.Byte>(someBytes, { prefix: 'log', strategy: 'unsafe-cast' });
 ```
 
 #### Replace `BoxRef` with `Box<bytes>`


### PR DESCRIPTION
This adds the migration guides for beta and tealscript that will be pulled into the devportal. I understand this is pointing to `main`, which is for beta releases, so let me know if I should change the target, or when this can be merged. 

Most of the content is borrowed from the guides in `docs/tealscript-migration` and `docs/beta-to-1-migration` branches, with some additions and code fixes.