### PR TITLE
Normalise document uris across the language server to resolve diagnostic responsiveness in webstorm

### DIFF
--- a/packages/algo-ts/package-lock.json
+++ b/packages/algo-ts/package-lock.json
@@ -1620,7 +1620,6 @@
       "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1678,7 +1677,6 @@
       "integrity": "sha512-JaehZvf6m0yqYp34+RVnihBAChkqeH+tqqhS0GuX1qgPpwLvmTPheKEs6OeCK6hVJgXZHJ2vbjnC9j119auStQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.33.0",
         "@typescript-eslint/types": "8.33.0",
@@ -2036,7 +2034,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2870,7 +2867,6 @@
       "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2932,7 +2928,6 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4939,7 +4934,6 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5156,7 +5150,6 @@
       "integrity": "sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -5925,7 +5918,6 @@
       "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -6036,7 +6028,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6112,7 +6103,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6211,7 +6201,6 @@
       "integrity": "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.1.4",
         "@vitest/mocker": "3.1.4",

--- a/src/language-server/util/uris.ts
+++ b/src/language-server/util/uris.ts
@@ -1,0 +1,66 @@
+import { globSync } from 'glob'
+import type {
+  DidChangeTextDocumentParams,
+  DidCloseTextDocumentParams,
+  DidOpenTextDocumentParams,
+  DidSaveTextDocumentParams,
+  Disposable,
+  NotificationHandler,
+  RequestHandler,
+  TextEdit,
+  WillSaveTextDocumentParams,
+} from 'vscode-languageserver-protocol'
+import type { TextDocumentConnection } from 'vscode-languageserver/lib/common/textDocuments'
+import type * as lsp from 'vscode-languageserver/node'
+import { URI } from 'vscode-uri'
+
+export function normalisedUri(args: { fsPath: string } | { uri: string }): URI {
+  if ('fsPath' in args) {
+    const resolvedFileName = globSync(args.fsPath)[0]
+
+    return URI.file(resolvedFileName ?? args.fsPath)
+  } else {
+    const filePath = URI.parse(args.uri).fsPath
+    return normalisedUri({ fsPath: filePath })
+  }
+}
+
+type TextDocumentConnectionEvents = Pick<lsp.Connection, keyof TextDocumentConnection>
+
+export function createNormalisedTextDocumentConnection(connection: lsp.Connection): TextDocumentConnectionEvents {
+  return {
+    onDidOpenTextDocument(handler: NotificationHandler<DidOpenTextDocumentParams>): Disposable {
+      return connection.onDidOpenTextDocument((params) =>
+        handler({ textDocument: { ...params.textDocument, uri: normalisedUri({ uri: params.textDocument.uri }).toString() } }),
+      )
+    },
+    onDidChangeTextDocument(handler: NotificationHandler<DidChangeTextDocumentParams>): Disposable {
+      return connection.onDidChangeTextDocument((params) =>
+        handler({ ...params, textDocument: { ...params.textDocument, uri: normalisedUri({ uri: params.textDocument.uri }).toString() } }),
+      )
+    },
+    onDidCloseTextDocument(handler: NotificationHandler<DidCloseTextDocumentParams>): Disposable {
+      return connection.onDidCloseTextDocument((params) =>
+        handler({ textDocument: { ...params.textDocument, uri: normalisedUri({ uri: params.textDocument.uri }).toString() } }),
+      )
+    },
+    onWillSaveTextDocument(handler: NotificationHandler<WillSaveTextDocumentParams>): Disposable {
+      return connection.onWillSaveTextDocument((params) =>
+        handler({ ...params, textDocument: { ...params.textDocument, uri: normalisedUri({ uri: params.textDocument.uri }).toString() } }),
+      )
+    },
+    onWillSaveTextDocumentWaitUntil(handler: RequestHandler<WillSaveTextDocumentParams, TextEdit[] | undefined | null, void>): Disposable {
+      return connection.onWillSaveTextDocumentWaitUntil((params, edits) =>
+        handler(
+          { ...params, textDocument: { ...params.textDocument, uri: normalisedUri({ uri: params.textDocument.uri }).toString() } },
+          edits,
+        ),
+      )
+    },
+    onDidSaveTextDocument(handler: NotificationHandler<DidSaveTextDocumentParams>): Disposable {
+      return connection.onDidSaveTextDocument((params) =>
+        handler({ textDocument: { ...params.textDocument, uri: normalisedUri({ uri: params.textDocument.uri }).toString() } }),
+      )
+    },
+  }
+}


### PR DESCRIPTION
There was inconsistent casing and character encoding between urls provided by the lsp4ij client and those produced by vscode's `URI.file(...)`. This PR passes all uris through a normalise function to achieve consistent casing and encoding. 