### PR TITLE
feat: LSP serverInfo

### DIFF
--- a/src/cli/app-version.ts
+++ b/src/cli/app-version.ts
@@ -3,25 +3,30 @@ import { fileURLToPath } from 'node:url'
 import pathe from 'pathe'
 import { Constants } from '../constants'
 
-export function appVersion(options?: { name?: string; withAVMVersion?: boolean }): string {
+export function packageVersion(): string {
   let dirName = pathe.dirname(fileURLToPath(import.meta.url))
-  const name = options?.name ?? 'puya-ts'
-  const withAVMVersion = options?.withAVMVersion ?? true
 
   while (true) {
     const packageJsonPath = pathe.join(dirName, 'package.json')
     if (fs.existsSync(packageJsonPath)) {
-      const version = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version
-      return [`${name} ${version}`]
-        .concat(
-          withAVMVersion
-            ? ['', 'Targets:', `puya ${Constants.targetedPuyaVersion}`, `AVM ${Constants.supportedAvmVersions.join(', ')}`]
-            : [`puya ${Constants.targetedPuyaVersion}`],
-        )
-        .join('\r\n')
+      return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version
     }
     if (dirName === pathe.dirname(dirName)) break
     dirName = pathe.dirname(dirName)
   }
-  return `Cannot determine puya-ts version`
+  return 'unknown'
+}
+
+export function appVersion(options?: { name?: string; withAVMVersion?: boolean }): string {
+  const name = options?.name ?? 'puya-ts'
+  const withAVMVersion = options?.withAVMVersion ?? true
+
+  const version = packageVersion()
+  return [`${name} ${version}`]
+    .concat(
+      withAVMVersion
+        ? ['', 'Targets:', `puya ${Constants.targetedPuyaVersion}`, `AVM ${Constants.supportedAvmVersions.join(', ')}`]
+        : [`puya ${Constants.targetedPuyaVersion}`],
+    )
+    .join('\n')
 }

--- a/src/language-server/puya-language-server.ts
+++ b/src/language-server/puya-language-server.ts
@@ -1,6 +1,6 @@
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import * as lsp from 'vscode-languageserver/node'
-import { appVersion } from '../cli/app-version'
+import { appVersion, packageVersion } from '../cli/app-version'
 import { Constants } from '../constants'
 import { logger, LogLevel } from '../logger'
 import { LanguageServerLogSink } from '../logger/sinks/language-server-log-sink'
@@ -39,6 +39,8 @@ export type LanguageServerOptions = {
   port?: number
   customPuyaPath?: string
 }
+
+const PACKAGE_VERSION = packageVersion()
 
 export class PuyaLanguageServer {
   readonly documents = new lsp.TextDocuments(TextDocument)
@@ -85,6 +87,10 @@ export class PuyaLanguageServer {
       workspaces: this.workspaceFolders,
     })
     return {
+      serverInfo: {
+        name: 'Puya-TS Language Server',
+        version: PACKAGE_VERSION,
+      },
       capabilities: {
         textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
         codeActionProvider: {


### PR DESCRIPTION
Adds an LSP serverInfo response. 

Also includes a small refactor to app-version to make it easier to get just the package version

Tested with neovim:

```
- puyats-ls (id: 2)
  - Version: 1.0.0
  - Root directory: ~/git/joe-p/snarkjs-algorand
  - Command: { "npx", "tsx", "/Users/joe/git/algorandfoundation/puya-ts/src/cli-ls.ts", "--stdio" }
  - Settings: {}
  - Attached buffers: 2
  ```
