### PR TITLE
Treat warnings as errors compile flag

### DIFF
--- a/src/cli/build-command.ts
+++ b/src/cli/build-command.ts
@@ -6,9 +6,9 @@ import { logger, LoggingContext, LogLevel } from '../logger'
 import { ConsoleLogSink } from '../logger/sinks/console-log-sink'
 import { CompileOptions, defaultPuyaOptions, LocalsCoalescingStrategy } from '../options'
 
+import { AbsolutePath } from '../util/absolute-path'
 import { parseCliTemplateVar } from '../util/template-var-cli-parser'
 import { addEnumArg, convertInt } from './util'
-import { AbsolutePath } from '../util/absolute-path'
 
 export interface BuildCommandArgs {
   command: 'build'
@@ -29,6 +29,7 @@ export interface BuildCommandArgs {
   out_dir: string
   debug_level: string
   optimization_level: string
+  treat_warnings_as_errors: boolean
   target_avm_version: string
   cli_template_definitions: string[]
   validate_abi_args: boolean
@@ -131,6 +132,11 @@ export function addBuildCommand(parser: ArgumentParser) {
     choices: ['0', '1', '2'],
     help: 'Set optimization level of output TEAL / AVM bytecode, 0 = none, 1 = normal, 2 = intensive',
   })
+  parser.add_argument('--treat-warnings-as-errors', {
+    action: BooleanOptionalAction,
+    default: defaultPuyaOptions.treatWarningsAsErrors,
+    help: 'Report and treat all warnings emitted by the compiler as errors',
+  })
   parser.add_argument('--target-avm-version', {
     default: defaultPuyaOptions.targetAvmVersion.toString(),
     choices: ['10', '11', '12', '13'],
@@ -207,6 +213,7 @@ export async function buildCommand(args: BuildCommandArgs) {
           outputSourceMap: args.output_source_map,
           debugLevel: convertInt(args.debug_level),
           optimizationLevel: convertInt(args.optimization_level),
+          treatWarningsAsErrors: args.treat_warnings_as_errors,
           targetAvmVersion: convertInt(args.target_avm_version),
           cliTemplateDefinitions: Object.fromEntries(args.cli_template_definitions?.map(parseCliTemplateVar) ?? []),
           templateVarsPrefix: args.template_vars_prefix,

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -22,6 +22,8 @@ export type CompileResult = {
 
 export async function compile(options: CompileOptions, puyaService?: PuyaService): Promise<CompileResult> {
   const loggerCtx = LoggingContext.current
+  if (options.treatWarningsAsErrors) loggerCtx.treatWarningsAsErrors = true
+
   registerPTypes(typeRegistry)
   logger.info(undefined, appVersion({ withAVMVersion: false }))
   const programResult = createTsProgram(options)

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -142,6 +142,7 @@ export class LoggingContext {
   #logEvents: LogEvent[] = []
   #sourcesByPath: Record<string, string[]> = {}
   #logEventsByPath: Record<string, LogEvent[]> = {}
+  treatWarningsAsErrors = false
 
   get logEvents(): readonly LogEvent[] {
     return this.#logEvents
@@ -164,6 +165,9 @@ export class LoggingContext {
   }
 
   addLog(log: LogEvent) {
+    if (this.treatWarningsAsErrors && log.level === LogLevel.Warning) {
+      log.level = LogLevel.Error
+    }
     this.#logEvents.push(log)
     const filePath = log.sourceLocation?.file?.toString()
     if (filePath) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -32,6 +32,7 @@ export class CompileOptions {
   public readonly outputSourceMap: boolean
   public readonly debugLevel: number
   public readonly optimizationLevel: number
+  public readonly treatWarningsAsErrors: boolean
   public readonly targetAvmVersion: number
   public readonly cliTemplateDefinitions: Record<string, Uint8Array | bigint>
   public readonly templateVarsPrefix: string
@@ -60,6 +61,7 @@ export class CompileOptions {
     this.outputSourceMap = options.outputSourceMap ?? false
     this.debugLevel = options.debugLevel ?? defaultPuyaOptions.debugLevel
     this.optimizationLevel = options.optimizationLevel ?? defaultPuyaOptions.optimizationLevel
+    this.treatWarningsAsErrors = options.treatWarningsAsErrors ?? defaultPuyaOptions.treatWarningsAsErrors
     this.targetAvmVersion = options.targetAvmVersion ?? defaultPuyaOptions.targetAvmVersion
     this.cliTemplateDefinitions = options.cliTemplateDefinitions ?? defaultPuyaOptions.cliTemplateDefinitions
     this.templateVarsPrefix = options.templateVarsPrefix ?? defaultPuyaOptions.templateVarsPrefix
@@ -98,6 +100,7 @@ export const defaultPuyaOptions: PuyaPassThroughOptions = {
   outputBytecode: false,
   debugLevel: 1,
   optimizationLevel: 1,
+  treatWarningsAsErrors: false,
   targetAvmVersion: 11,
   cliTemplateDefinitions: {},
   templateVarsPrefix: 'TMPL_',
@@ -119,6 +122,7 @@ export class PuyaOptions {
   outputSourceMap: boolean
   debugLevel: number
   optimizationLevel: number
+  treatWarningsAsErrors: boolean
   targetAvmVersion: number
   cliTemplateDefinitions: Record<string, Uint8Array | bigint>
   templateVarsPrefix: string
@@ -139,6 +143,7 @@ export class PuyaOptions {
     this.outputBytecode = options.outputBytecode
     this.debugLevel = options.debugLevel
     this.optimizationLevel = options.optimizationLevel
+    this.treatWarningsAsErrors = options.treatWarningsAsErrors
     this.targetAvmVersion = options.targetAvmVersion
     this.cliTemplateDefinitions = options.cliTemplateDefinitions
     this.templateVarsPrefix = options.templateVarsPrefix

--- a/tests/other/warn-as-errors/emit-warning-awst.algo.ts
+++ b/tests/other/warn-as-errors/emit-warning-awst.algo.ts
@@ -1,0 +1,6 @@
+import { abimethod, Contract } from '@algorandfoundation/algorand-typescript'
+
+class ContractLogsWarn extends Contract {
+  @abimethod({ allowActions: ['NoOp', 'NoOp'] })
+  public justNoop(): void {}
+}

--- a/tests/other/warn-as-errors/emit-warning-ir.algo.ts
+++ b/tests/other/warn-as-errors/emit-warning-ir.algo.ts
@@ -1,0 +1,7 @@
+import { assert, Contract } from '@algorandfoundation/algorand-typescript'
+
+class ContractLogsWarn extends Contract {
+  warn_assertion_always_true() {
+    assert(true)
+  }
+}

--- a/tests/warn-as-errors.spec.ts
+++ b/tests/warn-as-errors.spec.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, readdirSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+import { compile, CompileOptions, processInputPaths } from '../src'
+import { isErrorOrCritical, LoggingContext, LogLevel } from '../src/logger'
+
+describe('when compiling with the treatWarningsAsErrors flag set', async () => {
+  it('fails compilation and logs an error when a warning would be emitted (in the backend)', async () => {
+    const tempOut = mkdtempSync(join(tmpdir(), 'wae-test'))
+    const logCtx = LoggingContext.create()
+    await logCtx.run(() => {
+      const filePaths = processInputPaths({ paths: ['tests/other/warn-as-errors/emit-warning-ir.algo.ts'], outDir: tempOut })
+      return compile(
+        new CompileOptions({
+          filePaths,
+          dryRun: false,
+          logLevel: LogLevel.Warning,
+          skipVersionCheck: true,
+          // flag being tested
+          treatWarningsAsErrors: true,
+          outputSourceMap: false,
+          outputAwstJson: false,
+          outputAwst: false,
+          outputTeal: true,
+          outputArc32: false,
+          outputArc56: false,
+          outputSsaIr: false,
+        }),
+      )
+    })
+
+    // Expect at least one error log event due to -Werror upgrade
+    const errors = logCtx.logEvents.filter((l) => isErrorOrCritical(l.level))
+    if (errors.length === 0) {
+      expect.fail('Expected compilation to error under -Werror, but no error log events were emitted.')
+    }
+
+    // ensure the cause of failure is because of -Werror
+    expect(errors.map((e) => e.message)).toContain('assertion is always true, ignoring')
+
+    // ensure nothing was written to the temp dir (compilation failed)
+    expect(readdirSync(tempOut)).toHaveLength(0)
+  })
+
+  it('fails compilation and logs an error when a warning would be emitted (in the frontend)', async () => {
+    const logCtx = LoggingContext.create()
+    await logCtx.run(() => {
+      const filePaths = processInputPaths({ paths: ['tests/other/warn-as-errors/emit-warning-awst.algo.ts'] })
+      return compile(
+        new CompileOptions({
+          filePaths,
+          dryRun: true,
+          logLevel: LogLevel.Warning,
+          skipVersionCheck: true,
+          // flag being tested
+          treatWarningsAsErrors: true,
+          outputSourceMap: false,
+          outputAwstJson: false,
+          outputAwst: false,
+          outputTeal: true,
+          outputArc32: false,
+          outputArc56: false,
+          outputSsaIr: false,
+        }),
+      )
+    })
+
+    // Expect at least one error log event due to -Werror upgrade
+    const errors = logCtx.logEvents.filter((l) => isErrorOrCritical(l.level))
+    if (errors.length === 0) {
+      expect.fail('Expected compilation to error under -Werror, but no error log events were emitted.')
+    }
+
+    // ensure the cause of failure is because of -Werror
+    expect(errors.map((e) => e.message)).toContain('Duplicate on completion actions')
+
+    // ensure compilation halted
+    expect(logCtx.logEvents.some((l) => l.message?.includes('Compilation halted due to errors'))).toBe(true)
+  })
+})


### PR DESCRIPTION
Implements `-Werror` like compiler flag (see [this PR on Puya](https://github.com/algorandfoundation/puya/pull/614)).
Similarly to puyapy, a flag is introduced in the logging context to make sure warnings emitted during AWST construction are also captured.
Since the flag is set to be always false in analysis, the tests are just for compile calls, both in the front (AWST construction) and backends (IR buildling).
Note that this feature is still not part of a release in Puya.