### PR TITLE
Fix resolution of intersection types

### DIFF
--- a/tests/expected-output/intersection-types.algo.ts
+++ b/tests/expected-output/intersection-types.algo.ts
@@ -1,0 +1,21 @@
+import { type Account, Contract, Txn } from '@algorandfoundation/algorand-typescript'
+import { Uint32 } from '@algorandfoundation/algorand-typescript/arc4'
+
+type MyAccount = {
+  account: Account
+}
+
+type WithId = { id: Uint32 }
+
+type MyAccountWithId = MyAccount & WithId
+
+export class HelloWorld extends Contract {
+  // @expect-error {account:Account} & {id:Uint<32>} cannot be used as an ABI return type
+  hello(name: string): MyAccountWithId {
+    const account: MyAccountWithId = {
+      account: Txn.sender,
+      id: new Uint32(13),
+    }
+    return account
+  }
+}


### PR DESCRIPTION
This change moves code around so the error reported on #318 makes more sense now.

Now trying to compile the following contract:
```typescript
import { Account, Contract, Txn } from '@algorandfoundation/algorand-typescript'
import { Uint32 } from '@algorandfoundation/algorand-typescript/arc4'

type MyAccount = {
  account: Account
}

type WithId = { id: Uint32 }

type MyAccountWithId = MyAccount & WithId

export class HelloWorld extends Contract {
  hello(name: string): MyAccountWithId {
    const account: MyAccountWithId = {
      account: Txn.sender,
      id: new Uint32(13),
    }
    return account
  }
}
```

Results in the message:
```console
info: puya-ts 1.0.0
puya 5.7.1
repro.algo.ts:13:3 error: {account:Account} & {id:Uint<32>} cannot be used as an ABI return type
                           hello(name: string): MyAccountWithId {
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
info: Compilation halted due to errors
```
instead of:
```console
info: puya-ts 1.0.0
puya 5.7.1
repro.algo.ts:13:3 error: Non builtin type must have a name
                           hello(name: string): MyAccountWithId {
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
info: Compilation halted due to errors
```

This **does not fix** #318. A later PR will add support on specific circumstances :)