### PR TITLE
Fix audit warning for GHSA-7h2j-956f-4vf2. Bump minimatch for our code.

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -3,5 +3,10 @@
     "active": true,
     "notes": "GHSA-34x7-hfp2-rc4v: Hardlink path traversal in node-tar. Transitive dependency through npm itself. Requires untrusted tar extraction to exploit. Acceptable risk for development tooling.",
     "expiry": "2026-12-31"
+  },
+  "1112862": {
+    "active": true,
+    "notes": "GHSA-7h2j-956f-4vf2: Exponential memory consumption. Transitive dependency through npm/eslint/vitest/minimatch. Will at most result in a crash.",
+    "expiry": "2026-04-01"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "change-case": "^5.4.4",
         "cross-spawn": "7.0.6",
         "glob": "^11.1.0",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.1.2",
         "pathe": "^2.0.3",
         "polytype": "^0.17.0",
         "signal-exit": "^4.1.0",
@@ -1397,9 +1397,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
@@ -7876,12 +7876,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "@isaacs/brace-expansion": "^5.0.1"
       },
       "engines": {
         "node": "20 || >=22"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "change-case": "^5.4.4",
     "cross-spawn": "7.0.6",
     "glob": "^11.1.0",
-    "minimatch": "^10.0.3",
+    "minimatch": "^10.1.2",
     "pathe": "^2.0.3",
     "polytype": "^0.17.0",
     "signal-exit": "^4.1.0",

--- a/packages/algo-ts/.nsprc
+++ b/packages/algo-ts/.nsprc
@@ -1,1 +1,7 @@
-{}
+{
+  "1112862": {
+    "active": true,
+    "notes": "GHSA-7h2j-956f-4vf2: Exponential memory consumption. Transitive dependency through npm/eslint/vitest/minimatch. Will at most result in a crash.",
+    "expiry": "2026-04-01"
+  }
+}


### PR DESCRIPTION
We cannot solve it on the `npm` side but at least this bumps it for our own code.