### PR TITLE
chore: Migrate audit IDs to GHSA IDs (they are more stable)

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,17 +1,17 @@
 {
-  "1112659": {
+  "GHSA-34x7-hfp2-rc4v": {
     "active": true,
-    "notes": "GHSA-34x7-hfp2-rc4v: Hardlink path traversal in node-tar. Transitive dependency through npm itself. Requires untrusted tar extraction to exploit. Acceptable risk for development tooling.",
+    "notes": "Hardlink path traversal in node-tar. Transitive dependency through npm itself. Requires untrusted tar extraction to exploit. Acceptable risk for development tooling.",
     "expiry": "2026-12-31"
   },
-  "1112862": {
+  "GHSA-7h2j-956f-4vf2": {
     "active": true,
-    "notes": "GHSA-7h2j-956f-4vf2: Exponential memory consumption. Transitive dependency through npm/eslint/vitest/minimatch. Will at most result in a crash.",
+    "notes": "Exponential memory consumption. Transitive dependency through npm/eslint/vitest/minimatch. Will at most result in a crash.",
     "expiry": "2026-04-01"
   },
-  "1112810": {
+  "GHSA-3966-f6p6-2qr9": {
     "active": true,
-    "notes": "GHSA-3966-f6p6-2qr9: npm cli Uncontrolled Search Path Element Local Privilege Escalation Vulnerability. Transitive dependency through the npm cli. Exploitable only by a local attacker who already has the ability to execute low-privileged code on the system. Acceptable risk for development tooling.",
+    "notes": "npm cli Uncontrolled Search Path Element Local Privilege Escalation Vulnerability. Transitive dependency through the npm cli. Exploitable only by a local attacker who already has the ability to execute low-privileged code on the system. Acceptable risk for development tooling.",
     "expiry": "2026-12-31"
   }
 }

--- a/packages/algo-ts/.nsprc
+++ b/packages/algo-ts/.nsprc
@@ -1,12 +1,12 @@
 {
-  "1112862": {
+  "GHSA-7h2j-956f-4vf2": {
     "active": true,
-    "notes": "GHSA-7h2j-956f-4vf2: Exponential memory consumption. Transitive dependency through npm/eslint/vitest/minimatch. Will at most result in a crash.",
+    "notes": "Exponential memory consumption. Transitive dependency through npm/eslint/vitest/minimatch. Will at most result in a crash.",
     "expiry": "2026-04-01"
   },
-  "1112810": {
+  "GHSA-3966-f6p6-2qr9": {
     "active": true,
-    "notes": "GHSA-3966-f6p6-2qr9: npm cli Uncontrolled Search Path Element Local Privilege Escalation Vulnerability. Transitive dependency through the npm cli. Exploitable only by a local attacker who already has the ability to execute low-privileged code on the system. Acceptable risk for development tooling.",
+    "notes": "npm cli Uncontrolled Search Path Element Local Privilege Escalation Vulnerability. Transitive dependency through the npm cli. Exploitable only by a local attacker who already has the ability to execute low-privileged code on the system. Acceptable risk for development tooling.",
     "expiry": "2026-12-31"
   }
 }


### PR DESCRIPTION
Yesterday our CI started to fail again (after we had already put the exceptions) because an ID changed.

I hope GHSA IDs are more stable :)