### PR TITLE
Allow non-null assertion operator to become a no-op in non-nullable types (with warning and code-fix removal)

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,2 +1,32 @@
 {
+  "GHSA-83g3-92jg-28cx": {
+    "active": true,
+    "notes": "Hardlink path traversal in node-tar. Transitive dependency through npm itself. Requires untrusted tar extraction to exploit. Acceptable risk for development tooling.",
+    "expiry": "2026-12-31"
+  },
+  "GHSA-2g4f-4pwh-qvx6": {
+    "active": true,
+    "notes": "DoS in ajv. Transitive dependency through eslint itself. Acceptable risk for development tooling (does not affect the generated artifact).",
+    "expiry": "2026-12-31"
+  },
+  "GHSA-3ppc-4f35-3m26": {
+    "active": true,
+    "notes": "ReDoS in minimatch. Transitive dependency through @typescript-eslint/typescript-estree and test-exclude. Acceptable risk for development tooling (does not affect the generated artifact).",
+    "expiry": "2026-12-31"
+  },
+  "GHSA-7r86-cg39-jmmj": {
+    "active": true,
+    "notes": "ReDoS in minimatch (matchOne combinatorial backtracking). Transitive dependency through eslint and typescript-estree. Acceptable risk for development tooling (does not affect the generated artifact).",
+    "expiry": "2026-12-31"
+  },
+  "GHSA-23c5-xmqv-rm74": {
+    "active": true,
+    "notes": "ReDoS in minimatch (nested extglobs). Transitive dependency through eslint and typescript-estree. Acceptable risk for development tooling (does not affect the generated artifact).",
+    "expiry": "2026-12-31"
+  },
+  "GHSA-mw96-cpmx-2vgc": {
+    "active": true,
+    "notes": "Arbitrary file write via path traversal in rollup. Transitive dependency through build tooling. Acceptable risk for development tooling (does not affect the generated artifact).",
+    "expiry": "2026-12-31"
+  }
 }

--- a/packages/algo-ts/.nsprc
+++ b/packages/algo-ts/.nsprc
@@ -8,5 +8,20 @@
     "active": true,
     "notes": "ReDoS in minimatch. Transitive dependency through @typescript-eslint/typescript-estree and test-exclude. Acceptable risk for development tooling (does not affect the generated artifact).",
     "expiry": "2026-12-31"
+  },
+  "GHSA-7r86-cg39-jmmj": {
+    "active": true,
+    "notes": "ReDoS in minimatch (matchOne combinatorial backtracking). Transitive dependency through eslint and typescript-estree. Acceptable risk for development tooling (does not affect the generated artifact).",
+    "expiry": "2026-12-31"
+  },
+  "GHSA-23c5-xmqv-rm74": {
+    "active": true,
+    "notes": "ReDoS in minimatch (nested extglobs). Transitive dependency through eslint and typescript-estree. Acceptable risk for development tooling (does not affect the generated artifact).",
+    "expiry": "2026-12-31"
+  },
+  "GHSA-mw96-cpmx-2vgc": {
+    "active": true,
+    "notes": "Arbitrary file write via path traversal in rollup. Transitive dependency through build tooling. Acceptable risk for development tooling (does not affect the generated artifact).",
+    "expiry": "2026-12-31"
   }
 }

--- a/src/awst_build/ast-visitors/base-visitor.ts
+++ b/src/awst_build/ast-visitors/base-visitor.ts
@@ -2,9 +2,9 @@ import ts from 'typescript'
 import { nodeFactory } from '../../awst/node-factory'
 import { type Expression, type MethodDocumentation } from '../../awst/nodes'
 import type { SourceLocation } from '../../awst/source-location'
-import { InvalidNonNullAssertion } from '../../code-fix/invalid-non-null-assertion'
+import { NoOpNonNullAssertion } from '../../code-fix/no-op-non-null-assertion'
 import { LooseEqualityOperator } from '../../code-fix/loose-equality-operator'
-import { CodeError, FixableCodeError, InternalError, NotSupported } from '../../errors'
+import { CodeError, InternalError, NotSupported } from '../../errors'
 import { logger } from '../../logger'
 import { codeInvariant, invariant } from '../../util'
 import type { Expressions } from '../../visitor/syntax-names'
@@ -559,8 +559,8 @@ export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
     if (target instanceof OptionalExpressionBuilder) {
       return target.base
     }
-
-    throw new FixableCodeError(new InvalidNonNullAssertion({ sourceLocation: this.sourceLocation(node) }))
+    logger.addCodeFix(new NoOpNonNullAssertion({ sourceLocation: this.sourceLocation(node) }))
+    return target
   }
 
   visitSatisfiesExpression(node: ts.SatisfiesExpression): NodeBuilder {

--- a/src/awst_build/ptypes/index.ts
+++ b/src/awst_build/ptypes/index.ts
@@ -224,7 +224,7 @@ export class IntersectionPType extends TransientType {
       module: 'lib.d.ts',
       singleton: false,
       typeMessage: transientTypeErrors.intersectionTypes(name).usedAsType,
-      expressionMessage: transientTypeErrors.unionTypes(name).usedInExpression,
+      expressionMessage: transientTypeErrors.intersectionTypes(name).usedInExpression,
     })
     this.types = types
   }

--- a/src/code-fix/no-op-non-null-assertion.ts
+++ b/src/code-fix/no-op-non-null-assertion.ts
@@ -5,15 +5,14 @@ import type { TextEdit } from '../text-edit'
 import { getNodeRange } from '../text-edit'
 import { CodeFix } from './code-fix'
 
-export class InvalidNonNullAssertion extends CodeFix {
+export class NoOpNonNullAssertion extends CodeFix {
   constructor({ sourceLocation }: { sourceLocation: SourceLocation<ts.NonNullExpression> }) {
     super({
       sourceLocation,
-      errorMessage:
-        'The non-null assertion operator "!" is not valid here. It is only valid in limited scenarios where built in types require it. Eg. Array.prototype.pop',
+      errorMessage: 'The non-null assertion operator "!" has no effect (no-op) on non-optional types',
       fixMessage: "Remove '!'",
-      logLevel: LogLevel.Error,
-      edits: InvalidNonNullAssertion.buildEdits(sourceLocation.node),
+      logLevel: LogLevel.Warning,
+      edits: NoOpNonNullAssertion.buildEdits(sourceLocation.node),
     })
   }
 

--- a/tests/expected-output/non-null.algo.ts
+++ b/tests/expected-output/non-null.algo.ts
@@ -1,7 +1,7 @@
 import type { uint64 } from '@algorandfoundation/algorand-typescript'
 
 function test(someArray: uint64[]) {
-  // @expect-error The non-null assertion operator "!" is not valid here. It is only valid in limited scenarios where built in types require it. Eg. Array.prototype.pop
+  // @expect-warning The non-null assertion operator "!" has no effect (no-op) on non-optional types
   const notNeeded = someArray[0]!
 
   // @expect-error This expression requires a non-null assertion operator "!" immediately proceeding it

--- a/tests/expected-output/not-supported.algo.ts
+++ b/tests/expected-output/not-supported.algo.ts
@@ -66,7 +66,7 @@ function notNull(): uint64 {
   // @expect-error Union types are not valid as a variable, parameter, return, or property type. Expression type is uint64 | undefined
   const x: uint64 | undefined = 123
 
-  // @expect-error The non-null assertion operator "!" is not valid here...
+  // @expect-warning The non-null assertion operator "!" has no effect (no-op) on non-optional types
   return x!
 }
 


### PR DESCRIPTION
This PR addresses #326.

In TypeScript, the non-null assertion operator ('!') is erased during emit and only affects the static type by excluding null and undefined. When the operand is already non-nullable, the assertion has no type or runtime effect, and is therefore redundant (a no-op). In TS this would be caught via linter rules (see [here](https://typescript-eslint.io/rules/no-unnecessary-type-assertion/)) rather than making it a compile-time error.

To better align with TypeScript developer expectations, this change downgrades the current error to a warning for ineffectual non-null assertions (while still keeping the code-fix to remove them). This avoids rejecting otherwise valid programs while still getting rid of the no-op assertion.