### PR TITLE
fix: Make the basepath for our docs configurable

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,9 @@ npm run build
 npm run preview
 ```
 
+By default the build targets deployment on `https://algorandfoundation.github.io/puya-ts/`.
+If a build for a different site if needed the environment variables `ASTRO_SITE` and `ASTRO_BASE` can be set accordingly.
+
 > [!NOTE]
 > Root workspace dependencies must be installed first because the `starlight-typedoc` plugin references TypeScript source files in `../packages/algo-ts/src/`.
 
@@ -71,4 +74,4 @@ Docs are deployed to **GitHub Pages** via the `gh-pages.yml` workflow and are **
 | `main`    | Build verified (not deployed)              |
 | `release` | Built and deployed to GitHub Pages         |
 
-Site URL: `https://algorandfoundation.github.io/algorand-typescript/`
+Site URL: `https://algorandfoundation.github.io/puya-ts/`

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ npm run preview
 ```
 
 By default the build targets deployment on `https://algorandfoundation.github.io/puya-ts/`.
-If a build for a different site if needed the environment variables `ASTRO_SITE` and `ASTRO_BASE` can be set accordingly.
+If a build for a different site is needed the environment variables `ASTRO_SITE` and `ASTRO_BASE` can be set accordingly.
 
 > [!NOTE]
 > Root workspace dependencies must be installed first because the `starlight-typedoc` plugin references TypeScript source files in `../packages/algo-ts/src/`.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,14 +1,19 @@
 // @ts-check
+import { env } from 'node:process'
+
 import starlight from '@astrojs/starlight'
 import { defineConfig } from 'astro/config'
 import remarkGithubAlerts from 'remark-github-alerts'
 import starlightTypeDoc from 'starlight-typedoc'
 import sidebarConfig from './sidebar.config.json'
 
+const site = env.ASTRO_SITE || 'https://algorandfoundation.github.io'
+const base = env.ASTRO_BASE || '/puya-ts/'
+
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://algorandfoundation.github.io',
-  base: '/algorand-typescript/',
+  site,
+  base,
   markdown: {
     remarkPlugins: [remarkGithubAlerts],
   },

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -7,10 +7,10 @@ hero:
   tagline: Compile TypeScript smart contracts for the Algorand Virtual Machine
   actions:
     - text: Language Guide
-      link: /algorand-typescript/language-guide/
+      link: ./language-guide/
       icon: right-arrow
     - text: API Reference
-      link: /algorand-typescript/api/
+      link: ./api/
       variant: minimal
 ---
 


### PR DESCRIPTION
The current configuration pointer to `algorand-typescript` (the old repo name). This PR fixes the it and makes it configurable.