### PR TITLE
chore: check if targeting production release of puya, fail prod release otherwise

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,31 +19,18 @@ jobs:
 
   check-puya:
     name: 'Check puya dependency'
-    needs: ci-all
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-
-      - run: npm ci --ignore-scripts
-
-      - name: Download puya-ts artifact
-        uses: actions/download-artifact@v8
-        with:
-          pattern: 'puya-ts-node-22.x'
-          path: artifacts/puya-ts
-
-      - name: Check puya
+      - uses: actions/checkout@v6
+        with: { fetch-depth: 1 }
+      - name: Ensure targeted puya is a production release
         run: |
-          cd artifacts/puya-ts
-          node cli.mjs --version | grep -E "^puya [0-9]+\.[0-9]+\.[0-9]+$" || exit 1
+          version=$(grep -oP "targetedPuyaVersion\s*:\s*['\"]\K[^'\"]+" src/constants.ts)
+          echo "Targeted puya version: $version"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::targetedPuyaVersion '$version' is a pre-release; production releases require a stable puya version."
+            exit 1
+          fi
 
   check-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,10 +12,38 @@ permissions:
 
 jobs:
   ci-all:
-    name: "Build and test all packages"
+    name: 'Build and test all packages'
     uses: ./.github/workflows/ci-all.yml
     with:
       run-commit-lint: true
+
+  check-puya:
+    name: 'Check puya dependency'
+    needs: ci-all
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+
+      - run: npm ci --ignore-scripts
+
+      - name: Download puya-ts artifact
+        uses: actions/download-artifact@v8
+        with:
+          pattern: 'puya-ts-node-22.x'
+          path: artifacts/puya-ts
+
+      - name: Check puya
+        run: |
+          cd artifacts/puya-ts
+          node cli.mjs --version | grep -E "^puya [0-9]+\.[0-9]+\.[0-9]+$" || exit 1
 
   check-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,25 +12,10 @@ permissions:
 
 jobs:
   ci-all:
-    name: 'Build and test all packages'
+    name: "Build and test all packages"
     uses: ./.github/workflows/ci-all.yml
     with:
       run-commit-lint: true
-
-  check-puya:
-    name: 'Check puya dependency'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with: { fetch-depth: 1 }
-      - name: Ensure targeted puya is a production release
-        run: |
-          version=$(grep -oP "targetedPuyaVersion\s*:\s*['\"]\K[^'\"]+" src/constants.ts)
-          echo "Targeted puya version: $version"
-          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::targetedPuyaVersion '$version' is a pre-release; production releases require a stable puya version."
-            exit 1
-          fi
 
   check-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,26 @@ permissions:
   id-token: write
 
 jobs:
+  check-puya:
+    name: 'Check puya dependency'
+    if: github.ref_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with: { fetch-depth: 1 }
+      - name: Ensure targeted puya is a production release
+        run: |
+          version=$(grep -oP "targetedPuyaVersion\s*:\s*['\"]\K[^'\"]+" src/constants.ts)
+          echo "Targeted puya version: $version"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::targetedPuyaVersion '$version' is a pre-release; production releases require a stable puya version."
+            exit 1
+          fi
+
   ci:
     name: Build and test
+    needs: check-puya
+    if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/ci-all.yml
     with:
       run-commit-lint: false


### PR DESCRIPTION
- prevent `publish` workflow on `release` branch (i.e releasing a production version of `puya-ts`) if it is **NOT** targeting a **production** release of `puya`.