### PR TITLE
chore: tidy up and clean up

### DIFF
--- a/src/awst/wtypes.ts
+++ b/src/awst/wtypes.ts
@@ -86,8 +86,8 @@ export namespace wtypes {
   }
 
   export class WTuple extends WType {
-    types: WType[]
-    names: string[] | undefined
+    readonly types: WType[]
+    readonly names: string[] | undefined
     constructor(props: { names?: string[]; types: WType[]; name?: string }) {
       super({
         name: props.name ?? 'tuple',
@@ -144,7 +144,7 @@ export namespace wtypes {
     }
   }
   export class WGroupTransaction extends WType {
-    transactionType: TransactionKind | null
+    readonly transactionType: TransactionKind | null
     constructor({ transactionType }: { transactionType?: TransactionKind }) {
       super({
         name: transactionType === undefined ? 'group_transaction' : `group_transaction_${TransactionKind[transactionType]}`,
@@ -153,7 +153,7 @@ export namespace wtypes {
     }
   }
   export class WInnerTransaction extends WType {
-    transactionType: TransactionKind | null
+    readonly transactionType: TransactionKind | null
     constructor({ transactionType }: { transactionType?: TransactionKind }) {
       super({
         name: transactionType === undefined ? 'inner_transaction' : `inner_transaction_${TransactionKind[transactionType]}`,
@@ -162,7 +162,7 @@ export namespace wtypes {
     }
   }
   export class WInnerTransactionFields extends WType {
-    transactionType: TransactionKind | null
+    readonly transactionType: TransactionKind | null
     constructor({ transactionType, name }: { transactionType?: TransactionKind; name?: string }) {
       super({
         name: transactionType === undefined ? 'inner_transaction_fields' : `inner_transaction_fields_${TransactionKind[transactionType]}`,
@@ -172,7 +172,7 @@ export namespace wtypes {
   }
 
   export class WABICallInnerTransactionFields extends WInnerTransactionFields {
-    resultType: WType
+    readonly resultType: WType
     constructor({ returnType }: { returnType?: WType }) {
       super({
         transactionType: TransactionKind.appl,
@@ -218,10 +218,10 @@ export namespace wtypes {
   }
 
   export class ARC4Struct extends ARC4Type {
-    fields: WTypeField[]
-    sourceLocation: SourceLocation | null
-    frozen: boolean
-    desc: string | null
+    readonly fields: WTypeField[]
+    readonly sourceLocation: SourceLocation | null
+    readonly frozen: boolean
+    readonly desc: string | null
 
     constructor({
       fields,

--- a/src/awst/wtypes.ts
+++ b/src/awst/wtypes.ts
@@ -123,10 +123,10 @@ export namespace wtypes {
   export class ReferenceArray extends WType {
     readonly elementType: WType
     readonly sourceLocation: SourceLocation | null
-    readonly immutable = false
-    constructor(props: { itemType: WType; immutable: boolean; sourceLocation?: SourceLocation }) {
+    constructor(props: { itemType: WType; sourceLocation?: SourceLocation }) {
       super({
         name: `ref_array<${props.itemType.name}>`,
+        immutable: false,
       })
       this.elementType = props.itemType
       this.sourceLocation = props.sourceLocation ?? null

--- a/src/awst_build/ast-visitors/base-visitor.ts
+++ b/src/awst_build/ast-visitors/base-visitor.ts
@@ -2,8 +2,8 @@ import ts from 'typescript'
 import { nodeFactory } from '../../awst/node-factory'
 import { type Expression, type MethodDocumentation } from '../../awst/nodes'
 import type { SourceLocation } from '../../awst/source-location'
-import { NoOpNonNullAssertion } from '../../code-fix/no-op-non-null-assertion'
 import { LooseEqualityOperator } from '../../code-fix/loose-equality-operator'
+import { NoOpNonNullAssertion } from '../../code-fix/no-op-non-null-assertion'
 import { CodeError, InternalError, NotSupported } from '../../errors'
 import { logger } from '../../logger'
 import { codeInvariant, invariant } from '../../util'
@@ -110,7 +110,7 @@ export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
     }
     const ptype = this.context.getPTypeForNode(node)
     invariant(ptype instanceof NumericLiteralPType, 'ptype should be NumericLiteralPType')
-    return new NumericLiteralExpressionBuilder(literalValue, ptype, this.sourceLocation(node))
+    return new NumericLiteralExpressionBuilder(literalValue, ptype, sourceLocation)
   }
 
   visitIdentifier(node: ts.Identifier): NodeBuilder {
@@ -207,13 +207,11 @@ export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
          */
         if (isMutableType(spreadExpr.ptype) && !containsMutableType(spreadExpr.ptype)) {
           toConcat.push(CloneFunctionBuilder.clone(spreadExpr, this.sourceLocation(element)))
+        } else if (spreadExpr.checkForUnclonedMutables('being spread into an array literal')) {
+          // Add a clone if one is required so we don't get cascading errors
+          toConcat.push(CloneFunctionBuilder.clone(spreadExpr, this.sourceLocation(element)))
         } else {
-          if (spreadExpr.checkForUnclonedMutables('being spread into an array literal')) {
-            // Add a clone if one is required so we don't get cascading errors
-            toConcat.push(CloneFunctionBuilder.clone(spreadExpr, this.sourceLocation(element)))
-          } else {
-            toConcat.push(spreadExpr)
-          }
+          toConcat.push(spreadExpr)
         }
       } else {
         itemBuffer.push(requireInstanceBuilder(this.baseAccept(element)))
@@ -613,13 +611,8 @@ export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
   }
 
   protected getNodeDescription(node: ts.Node): string | null {
-    const docs = ts.getJSDocCommentsAndTags(node)
-    for (const doc of docs) {
-      if (ts.isJSDoc(doc)) {
-        return ts.getTextOfJSDocComment(doc.comment) ?? null
-      }
-    }
-    return null
+    const jsdoc = ts.getJSDocCommentsAndTags(node).find(ts.isJSDoc)
+    return jsdoc ? (ts.getTextOfJSDocComment(jsdoc.comment) ?? null) : null
   }
 
   protected getMethodDocumentation(node: ts.FunctionDeclaration | ts.MethodDeclaration | ts.ConstructorDeclaration): MethodDocumentation {

--- a/src/awst_build/ast-visitors/base-visitor.ts
+++ b/src/awst_build/ast-visitors/base-visitor.ts
@@ -476,7 +476,7 @@ export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
     })
   }
 
-  createConditionalExpression({
+  private createConditionalExpression({
     condition,
     ptype,
     whenFalse,

--- a/src/awst_build/ast-visitors/base-visitor.ts
+++ b/src/awst_build/ast-visitors/base-visitor.ts
@@ -49,13 +49,9 @@ const OPTIONAL_CHAINING_MESSAGE = 'The optional chaining (?.) operator is not su
 
 export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
   private baseAccept = <TNode extends ts.Node>(node: TNode) => accept<BaseVisitor, TNode>(this, node)
-  readonly textVisitor: TextVisitor
+  readonly textVisitor = new TextVisitor()
   get context() {
     return AwstBuildContext.current
-  }
-
-  protected constructor() {
-    this.textVisitor = new TextVisitor()
   }
 
   logNotSupported(node: ts.Node | undefined, message: string) {
@@ -129,7 +125,7 @@ export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
     this.throwNotSupported(node, 'Null values')
   }
 
-  visitPrivateIdentifier(node: ts.PrivateIdentifier): NodeBuilder {
+  visitPrivateIdentifier(_node: ts.PrivateIdentifier): NodeBuilder {
     // Private identifiers will be wrapped in a property access expression which makes use of the TextVisitor
     throw InternalError.shouldBeUnreachable()
   }

--- a/src/awst_build/ast-visitors/base-visitor.ts
+++ b/src/awst_build/ast-visitors/base-visitor.ts
@@ -45,6 +45,8 @@ import { instanceEb, typeRegistry } from '../type-registry'
 import { handleAssignment } from './assignments'
 import { TextVisitor } from './text-visitor'
 
+const OPTIONAL_CHAINING_MESSAGE = 'The optional chaining (?.) operator is not supported'
+
 export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
   private baseAccept = <TNode extends ts.Node>(node: TNode) => accept<BaseVisitor, TNode>(this, node)
   readonly textVisitor: TextVisitor
@@ -236,7 +238,7 @@ export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
   }
 
   visitPropertyAccessExpression(node: ts.PropertyAccessExpression): NodeBuilder {
-    this.logNotSupported(node.questionDotToken, 'The optional chaining (?.) operator is not supported')
+    this.logNotSupported(node.questionDotToken, OPTIONAL_CHAINING_MESSAGE)
     const target = this.baseAccept(node.expression)
     if (target instanceof NamespaceBuilder) {
       codeInvariant(!ts.isPrivateIdentifier(node.name), 'Private identifiers are not supported here', this.sourceLocation(node.name))
@@ -247,7 +249,7 @@ export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
   }
 
   visitElementAccessExpression(node: ts.ElementAccessExpression): NodeBuilder {
-    this.logNotSupported(node.questionDotToken, 'The optional chaining (?.) operator is not supported')
+    this.logNotSupported(node.questionDotToken, OPTIONAL_CHAINING_MESSAGE)
 
     const sourceLocation = this.sourceLocation(node)
     const target = this.baseAccept(node.expression)
@@ -256,7 +258,7 @@ export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
   }
 
   visitCallExpression(node: ts.CallExpression): NodeBuilder {
-    this.logNotSupported(node.questionDotToken, 'The optional chaining (?.) operator is not supported')
+    this.logNotSupported(node.questionDotToken, OPTIONAL_CHAINING_MESSAGE)
     const sourceLocation = this.sourceLocation(node)
     const eb = this.baseAccept(node.expression)
     const args = node.arguments

--- a/src/awst_build/ast-visitors/base-visitor.ts
+++ b/src/awst_build/ast-visitors/base-visitor.ts
@@ -460,7 +460,7 @@ export abstract class BaseVisitor implements Visitor<Expressions, NodeBuilder> {
         right.ptype,
       )
     }
-    throw new NotSupported(`Binary expression with op ${getSyntaxName(binaryOpKind)}`)
+    this.throwNotSupported(node, `Binary expression with op ${getSyntaxName(binaryOpKind)}`)
   }
 
   visitConditionalExpression(node: ts.ConditionalExpression): NodeBuilder {

--- a/src/awst_build/ast-visitors/constructor-visitor.ts
+++ b/src/awst_build/ast-visitors/constructor-visitor.ts
@@ -29,7 +29,7 @@ export class ConstructorVisitor extends ContractMethodBaseVisitor {
     const { args, body, documentation } = this.buildFunctionAwst()
     return new awst.ContractMethod({
       arc4MethodConfig: null,
-      memberName: this._functionType.name,
+      memberName: this.functionType.name,
       sourceLocation,
       args,
       returnType: voidPType.wtype,

--- a/src/awst_build/ast-visitors/contract-method-visitor.ts
+++ b/src/awst_build/ast-visitors/contract-method-visitor.ts
@@ -268,7 +268,7 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
     config: Arc4AbiDecoratorData['defaultArguments'][string]
     decoratorLocation: SourceLocation
   }): ABIMethodArgMemberDefault | ABIMethodArgConstantDefault {
-    const [, paramType] = this._contractType.methods[methodName].parameters.find(([p]) => p === parameterName) ?? [undefined, undefined]
+    const paramType = this._contractType.methods[methodName].parameters.find(([p]) => p === parameterName)?.[1]
     codeInvariant(
       paramType,
       `Default argument specification '${parameterName}' does not match any parameters on the target method`,

--- a/src/awst_build/ast-visitors/contract-method-visitor.ts
+++ b/src/awst_build/ast-visitors/contract-method-visitor.ts
@@ -144,7 +144,7 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
 
     this.validateDecoratorRoutingData(functionType, decorator, conventionalDefaults)
 
-    if (decorator?.type === 'arc4.baremethod') {
+    if (decorator?.type === Constants.symbolNames.arc4BareDecoratorName) {
       this.checkBareMethodTypes(functionType, methodLocation)
       return new ARC4BareMethodConfig({
         sourceLocation: decorator.sourceLocation,
@@ -154,7 +154,7 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
       })
     }
 
-    if (decorator?.type === 'arc4.abimethod') {
+    if (decorator?.type === Constants.symbolNames.arc4AbiDecoratorName) {
       return new ARC4ABIMethodConfig({
         readonly: decorator.readonly ?? false,
         sourceLocation: decorator.sourceLocation,
@@ -196,7 +196,7 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
     decorator: RoutingDecoratorData | undefined,
     impliedByConvention: RoutingProps | undefined,
   ) {
-    if (!decorator || !impliedByConvention || decorator.type === 'arc4.readonly') return
+    if (!decorator || !impliedByConvention || decorator.type === Constants.symbolNames.readonlyDecoratorName) return
 
     if (
       decorator.allowedCompletionTypes !== undefined &&

--- a/src/awst_build/ast-visitors/contract-method-visitor.ts
+++ b/src/awst_build/ast-visitors/contract-method-visitor.ts
@@ -67,7 +67,7 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
     const modifiers = this.parseMemberModifiers(node)
 
     const arc4MethodConfig = this.buildArc4Config({
-      functionType: this._functionType,
+      functionType: this.functionType,
       decorator,
       modifiers,
       methodLocation: sourceLocation,
@@ -78,7 +78,7 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
         contractReference: cref,
         sourceLocation,
         arc4MethodConfig,
-        memberName: this._functionType.name,
+        memberName: this.functionType.name,
       })
     this.metaData = {
       arc4MethodConfig,
@@ -92,10 +92,10 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
 
     return new ContractMethod({
       arc4MethodConfig: this.metaData.arc4MethodConfig,
-      memberName: this._functionType.name,
+      memberName: this.functionType.name,
       sourceLocation: this.metaData.sourceLocation,
       args,
-      returnType: this._functionType.returnType.wtypeOrThrow,
+      returnType: this.functionType.returnType.wtypeOrThrow,
       body,
       cref: this.metaData.cref,
       documentation,

--- a/src/awst_build/ast-visitors/contract-method-visitor.ts
+++ b/src/awst_build/ast-visitors/contract-method-visitor.ts
@@ -2,8 +2,7 @@ import type ts from 'typescript'
 import { ContractReference, OnCompletionAction } from '../../awst/models'
 import { nodeFactory } from '../../awst/node-factory'
 import type { ABIMethodArgConstantDefault, ABIMethodArgMemberDefault, ARC4MethodConfig } from '../../awst/nodes'
-import * as awst from '../../awst/nodes'
-import { ARC4ABIMethodConfig, ARC4BareMethodConfig, ARC4CreateOption } from '../../awst/nodes'
+import { ARC4ABIMethodConfig, ARC4BareMethodConfig, ARC4CreateOption, ContractMethod } from '../../awst/nodes'
 import type { SourceLocation } from '../../awst/source-location'
 import { Constants } from '../../constants'
 import { CodeError } from '../../errors'
@@ -91,7 +90,7 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
   get result() {
     const { args, body, documentation } = this.buildFunctionAwst()
 
-    return new awst.ContractMethod({
+    return new ContractMethod({
       arc4MethodConfig: this.metaData.arc4MethodConfig,
       memberName: this._functionType.name,
       sourceLocation: this.metaData.sourceLocation,
@@ -105,7 +104,7 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
     })
   }
 
-  public static buildContractMethod(node: ts.MethodDeclaration, contractType: ContractClassPType): () => awst.ContractMethod {
+  public static buildContractMethod(node: ts.MethodDeclaration, contractType: ContractClassPType): () => ContractMethod {
     return visitInChildContext(this, node, contractType)
   }
 
@@ -119,7 +118,7 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
     decorator: RoutingDecoratorData | undefined
     modifiers: { isPublic: boolean; isStatic: boolean }
     methodLocation: SourceLocation
-  }): awst.ARC4MethodConfig | null {
+  }): ARC4MethodConfig | null {
     const isProgramMethod = isIn(functionType.name, [
       Constants.symbolNames.approvalProgramMethodName,
       Constants.symbolNames.clearStateProgramMethodName,
@@ -177,7 +176,7 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
           ]),
         ),
       })
-    } else if (isPublic && this._contractType.isARC4) {
+    } else if (this._contractType.isARC4) {
       return new ARC4ABIMethodConfig({
         allowedCompletionTypes: conventionalDefaults?.allowedCompletionTypes ?? unspecifiedDefaults.allowedCompletionTypes,
         create: conventionalDefaults?.create ?? unspecifiedDefaults.create,

--- a/src/awst_build/ast-visitors/contract-method-visitor.ts
+++ b/src/awst_build/ast-visitors/contract-method-visitor.ts
@@ -252,7 +252,7 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
     }
   }
 
-  checkBareMethodTypes(functionType: FunctionPType, sourceLocation: SourceLocation) {
+  private checkBareMethodTypes(functionType: FunctionPType, sourceLocation: SourceLocation) {
     codeInvariant(functionType.parameters.length === 0, 'Bare methods cannot have any parameters', sourceLocation)
     codeInvariant(functionType.returnType.equals(voidPType), 'Bare method return type must be void', sourceLocation)
   }

--- a/src/awst_build/ast-visitors/contract-method-visitor.ts
+++ b/src/awst_build/ast-visitors/contract-method-visitor.ts
@@ -45,6 +45,12 @@ type RoutingProps = {
   create?: ARC4CreateOption
 }
 
+// Default routing properties used when these values aren't specified explicitly.
+const unspecifiedDefaults = {
+  allowedCompletionTypes: [OnCompletionAction.NoOp],
+  create: ARC4CreateOption.disallow,
+}
+
 export class ContractMethodVisitor extends ContractMethodBaseVisitor {
   private readonly metaData: {
     cref: ContractReference
@@ -138,12 +144,6 @@ export class ContractMethodVisitor extends ContractMethodBaseVisitor {
     const conventionalDefaults = this.getConventionalRoutingConfig(functionType.name)
 
     this.validateDecoratorRoutingData(functionType, decorator, conventionalDefaults)
-
-    // Default routing properties used when these values aren't specified explicitly.
-    const unspecifiedDefaults = {
-      allowedCompletionTypes: [OnCompletionAction.NoOp],
-      create: ARC4CreateOption.disallow,
-    }
 
     if (decorator?.type === 'arc4.baremethod') {
       this.checkBareMethodTypes(functionType, methodLocation)

--- a/src/awst_build/ast-visitors/function-visitor.ts
+++ b/src/awst_build/ast-visitors/function-visitor.ts
@@ -110,7 +110,10 @@ export abstract class FunctionVisitor
         throw new InternalError('Unhandled binding name', { sourceLocation })
     }
   }
-  evaluateParameterBindingExpressions(parameters: Iterable<ts.ParameterDeclaration>, sourceLocation: SourceLocation): awst.Statement[] {
+  private evaluateParameterBindingExpressions(
+    parameters: Iterable<ts.ParameterDeclaration>,
+    sourceLocation: SourceLocation,
+  ): awst.Statement[] {
     const assignments: awst.Statement[] = []
     for (const p of parameters) {
       const sourceLocation = this.sourceLocation(p)

--- a/src/awst_build/ast-visitors/function-visitor.ts
+++ b/src/awst_build/ast-visitors/function-visitor.ts
@@ -145,7 +145,7 @@ export abstract class FunctionVisitor
     ]
   }
 
-  visitTypeAliasDeclaration(node: ts.TypeAliasDeclaration): awst.Statement[] {
+  visitTypeAliasDeclaration(_node: ts.TypeAliasDeclaration): awst.Statement[] {
     return []
   }
 

--- a/src/awst_build/ast-visitors/function-visitor.ts
+++ b/src/awst_build/ast-visitors/function-visitor.ts
@@ -36,13 +36,13 @@ export abstract class FunctionVisitor
 {
   protected accept = <TNode extends ts.Node>(node: TNode) => accept<FunctionVisitor, TNode>(this, node)
 
-  protected readonly _functionType: FunctionPType
+  protected readonly functionType: FunctionPType
 
   constructor(protected readonly node: ts.MethodDeclaration | ts.FunctionDeclaration | ts.ConstructorDeclaration) {
     super()
     const type = this.context.getPTypeForNode(node)
     invariant(type instanceof FunctionPType, 'type of function must be FunctionPType')
-    this._functionType = type
+    this.functionType = type
   }
 
   protected buildFunctionAwst(): {
@@ -384,7 +384,7 @@ export abstract class FunctionVisitor
     const returnValue = this.accept(node.expression)
     return nodeFactory.returnStatement({
       sourceLocation: sourceLocation,
-      value: requireExpressionOfType(returnValue, this._functionType.returnType),
+      value: requireExpressionOfType(returnValue, this.functionType.returnType),
     })
   }
   visitWithStatement(node: ts.WithStatement): awst.Statement | awst.Statement[] {

--- a/src/awst_build/ast-visitors/function-visitor.ts
+++ b/src/awst_build/ast-visitors/function-visitor.ts
@@ -75,7 +75,7 @@ export abstract class FunctionVisitor
           const sourceLocation = this.sourceLocation(element)
 
           const propertyNameIdentifier = element.propertyName ?? element.name
-          invariant(ts.isIdentifier(propertyNameIdentifier), 'propertyName must be an identifier')
+          codeInvariant(ts.isIdentifier(propertyNameIdentifier), 'propertyName must be an identifier', sourceLocation)
 
           const propertyName = this.textVisitor.accept(propertyNameIdentifier)
           codeInvariant(!element.dotDotDotToken, 'Spread operator is not supported here', sourceLocation)
@@ -163,7 +163,7 @@ export abstract class FunctionVisitor
         // Typescript will already error if a destructuring expression is used without an initializer
         if (ts.isIdentifier(d.name)) {
           const ptype = this.context.getPTypeForNode(d.name)
-          codeInvariant(ptype.wtype, `${ptype.fullName} is not a valid variable type`)
+          codeInvariant(ptype.wtype, `${ptype.fullName} is not a valid variable type`, sourceLocation)
         }
         return []
       }
@@ -451,7 +451,9 @@ export abstract class FunctionVisitor
     return []
   }
   visitImportDeclaration(node: ts.ImportDeclaration): awst.Statement | awst.Statement[] {
-    throw new NotSupported('Non-top-level import declarations')
+    throw new NotSupported('Non-top-level import declarations', {
+      sourceLocation: this.sourceLocation(node),
+    })
   }
 
   visitBlock(node: ts.Block): awst.Block {

--- a/src/awst_build/ast-visitors/function-visitor.ts
+++ b/src/awst_build/ast-visitors/function-visitor.ts
@@ -88,7 +88,7 @@ export abstract class FunctionVisitor
       case ts.SyntaxKind.ArrayBindingPattern: {
         const items: InstanceBuilder[] = []
         for (const element of bindingName.elements) {
-          const sourceLocation = this.context.getSourceLocation(element)
+          const sourceLocation = this.sourceLocation(element)
 
           if (ts.isOmittedExpression(element)) {
             items.push(new OmittedExpressionBuilder(sourceLocation))
@@ -309,13 +309,14 @@ export abstract class FunctionVisitor
     const condition = this.evaluateCondition(node.expression)
 
     const ifBranch = nodeFactory.block({ sourceLocation: this.sourceLocation(node.thenStatement) }, this.accept(node.thenStatement))
-    const elseBranch =
-      node.elseStatement && nodeFactory.block({ sourceLocation: this.sourceLocation(node.elseStatement) }, this.accept(node.elseStatement))
+    const elseBranch = node.elseStatement
+      ? nodeFactory.block({ sourceLocation: this.sourceLocation(node.elseStatement) }, this.accept(node.elseStatement))
+      : null
 
     return nodeFactory.ifElse({
       condition,
       ifBranch,
-      elseBranch: elseBranch ?? null,
+      elseBranch: elseBranch,
       sourceLocation,
     })
   }

--- a/src/awst_build/ast-visitors/logic-sig-program-visitor.ts
+++ b/src/awst_build/ast-visitors/logic-sig-program-visitor.ts
@@ -12,11 +12,11 @@ export class LogicSigProgramVisitor extends FunctionVisitor {
     const sourceLocation = this.sourceLocation(this.node)
     const { args, body, documentation } = this.buildFunctionAwst()
     return new awst.Subroutine({
-      id: this._functionType.fullName,
-      name: this._functionType.name,
+      id: this.functionType.fullName,
+      name: this.functionType.name,
       sourceLocation,
       args,
-      returnType: this._functionType.returnType.wtypeOrThrow,
+      returnType: this.functionType.returnType.wtypeOrThrow,
       body,
       documentation,
       inline: null,

--- a/src/awst_build/ast-visitors/subroutine-visitor.ts
+++ b/src/awst_build/ast-visitors/subroutine-visitor.ts
@@ -14,11 +14,11 @@ export class SubroutineVisitor extends FunctionVisitor {
     const { args, body, documentation } = this.buildFunctionAwst()
 
     return new awst.Subroutine({
-      id: this._functionType.fullName,
-      name: this._functionType.name,
+      id: this.functionType.fullName,
+      name: this.functionType.name,
       sourceLocation,
       args,
-      returnType: this._functionType.returnType.wtypeOrThrow,
+      returnType: this.functionType.returnType.wtypeOrThrow,
       body,
       documentation,
       inline: null,

--- a/src/awst_build/context/awst-build-context.ts
+++ b/src/awst_build/context/awst-build-context.ts
@@ -188,35 +188,39 @@ class AwstBuildContextImpl extends AwstBuildContext {
     contractConfig.set(memberName, arc4MethodConfig)
   }
 
+  private *iterateContractHierarchy(contractType: ContractClassPType): IterableIterator<ContractClassPType> {
+    const seen = new Set<string>()
+    for (const ct of [contractType, ...contractType.allBases()]) {
+      if (seen.has(ct.fullName)) continue
+      seen.add(ct.fullName)
+      yield ct
+    }
+  }
+
+  private *iterateMethodNameToConfigMap(contractType: ContractClassPType): IterableIterator<Map<string, ARC4MethodConfig>> {
+    for (const ct of this.iterateContractHierarchy(contractType)) {
+      if (ct.equals(baseContractType) || ct.equals(arc4BaseContractType) || ct instanceof ClusteredContractClassType) continue
+      const contractMethods = this.arc4MethodConfig.get(ct.fullName)
+      if (contractMethods) yield contractMethods
+    }
+  }
+
   getArc4Config(contractType: ContractClassPType): ARC4MethodConfig[]
   getArc4Config(contractType: ContractClassPType, memberName: string): ARC4MethodConfig | undefined
   getArc4Config(contractType: ContractClassPType, memberName?: string): ARC4MethodConfig | undefined | ARC4MethodConfig[] {
-    if (memberName) {
-      for (const ct of [contractType, ...contractType.allBases()]) {
-        if (ct.equals(baseContractType) || ct.equals(arc4BaseContractType) || ct instanceof ClusteredContractClassType) continue
-
-        const contractMethods = this.arc4MethodConfig.get(ct.fullName)
-        if (!contractMethods) continue
-        if (contractMethods.has(memberName)) {
-          return contractMethods.get(memberName)
-        }
+    if (memberName !== undefined) {
+      for (const methods of this.iterateMethodNameToConfigMap(contractType)) {
+        if (methods.has(memberName)) return methods.get(memberName)
       }
       return undefined
-    } else {
-      return Array.from(
-        [contractType, ...contractType.allBases()]
-          .toReversed()
-          .reduce((acc, ct) => {
-            if (ct.equals(baseContractType) || ct.equals(arc4BaseContractType) || ct instanceof ClusteredContractClassType) return acc
-
-            const contractMethods = this.arc4MethodConfig.get(ct.fullName)
-            if (!contractMethods) return acc
-
-            return new Map([...acc, ...contractMethods])
-          }, new Map<string, ARC4MethodConfig>())
-          .values(),
-      )
     }
+    const result = new Map<string, ARC4MethodConfig>()
+    for (const methods of this.iterateMethodNameToConfigMap(contractType)) {
+      for (const [name, cfg] of methods) {
+        if (!result.has(name)) result.set(name, cfg)
+      }
+    }
+    return Array.from(result.values())
   }
 
   static forProgram(program: ts.Program, options: BuildAwstOptions): AwstBuildContext {
@@ -314,22 +318,16 @@ class AwstBuildContextImpl extends AwstBuildContext {
   }
 
   getStorageDeclaration(contractType: ContractClassPType, memberName: string): AppStorageDeclaration | undefined {
-    const declaration = this.storageDeclarations.get(contractType.fullName)?.get(memberName)
-    if (declaration) return declaration
-    for (const baseType of contractType.baseTypes) {
-      const baseDeclaration = this.getStorageDeclaration(baseType, memberName)
-      if (baseDeclaration) return baseDeclaration
+    for (const ct of this.iterateContractHierarchy(contractType)) {
+      const declaration = this.storageDeclarations.get(ct.fullName)?.get(memberName)
+      if (declaration) return declaration
     }
     return undefined
   }
 
   getStorageDefinitionsForContract(contractType: ContractClassPType): AppStorageDefinition[] {
     const result = new Map<string, AppStorageDefinition>()
-    const seenContracts = new Set<string>()
-    for (const ct of [contractType, ...contractType.allBases()]) {
-      if (seenContracts.has(ct.fullName)) continue
-      seenContracts.add(ct.fullName)
-
+    for (const ct of this.iterateContractHierarchy(contractType)) {
       for (const [memberName, declaration] of this.storageDeclarations.get(ct.fullName) ?? []) {
         if (result.has(memberName)) {
           logger.error(

--- a/src/awst_build/context/awst-build-context.ts
+++ b/src/awst_build/context/awst-build-context.ts
@@ -100,8 +100,8 @@ export abstract class AwstBuildContext {
   }): void
   abstract registerContractType(contractType: ContractClassPType): void
   abstract getContractTypeByName(contractName: SymbolName): ContractClassPType | undefined
-  abstract getArc4Config(contractType: ContractClassPType, memberName: string): ARC4MethodConfig | undefined
   abstract getArc4Config(contractType: ContractClassPType): ARC4MethodConfig[]
+  abstract getArc4Config(contractType: ContractClassPType, memberName: string): ARC4MethodConfig | undefined
 
   abstract getStorageDeclaration(contractType: ContractClassPType, memberName: string): AppStorageDeclaration | undefined
 
@@ -272,7 +272,7 @@ class AwstBuildContextImpl extends AwstBuildContext {
     return this.nameResolver.resolveUniqueName(node.text, symbol)
   }
 
-  getTypeParameters(node: ts.CallExpression | ts.NewExpression): PType[] {
+  getTypeParameters(node: ts.CallExpression | ts.NewExpression | ts.TaggedTemplateExpression): PType[] {
     return this.typeResolver.resolveTypeParameters(node, this.getSourceLocation(node))
   }
 

--- a/src/awst_build/eb/arc4/arrays.ts
+++ b/src/awst_build/eb/arc4/arrays.ts
@@ -18,7 +18,7 @@ import {
   DynamicArrayGeneric,
   DynamicArrayType,
   DynamicBytesConstructor,
-  DynamicBytesType,
+  dynamicBytesType,
   StaticArrayGeneric,
   StaticArrayType,
   StaticBytesGeneric,
@@ -239,7 +239,7 @@ export class DynamicBytesClassBuilder extends ClassBuilder {
       genericTypeArgs: 0,
       argSpec: (a) => [a.optional(bytesPType, stringPType)],
     })
-    const resultPType = DynamicBytesType
+    const resultPType = dynamicBytesType
 
     if (!initialValue) {
       return instanceEb(

--- a/src/awst_build/eb/arc4/base.ts
+++ b/src/awst_build/eb/arc4/base.ts
@@ -44,7 +44,6 @@ export class Arc4EncodedBaseExpressionBuilder<T extends ARC4EncodedType> extends
       case 'equals':
         return new Arc4EqualsFunctionBuilder(this, sourceLocation)
       case 'native':
-        if (this.ptype.nativeType === undefined) break
         return instanceEb(
           nodeFactory.aRC4Decode({
             value: this.resolve(),

--- a/src/awst_build/eb/arc4/c2c.ts
+++ b/src/awst_build/eb/arc4/c2c.ts
@@ -374,7 +374,7 @@ function getImplicitFields({
   sourceLocation,
 }: {
   applicationProxy: InstanceBuilder
-  methodConfig: ARC4ABIMethodConfig | ARC4BareMethodConfig
+  methodConfig: ARC4MethodConfig
   mappedFields: ReadonlyMap<TxnField, Expression>
   sourceLocation: SourceLocation
 }) {

--- a/src/awst_build/eb/arc4/c2c.ts
+++ b/src/awst_build/eb/arc4/c2c.ts
@@ -284,8 +284,8 @@ export function buildApplicationCallTxnFields({
   // Build itxn and submit
   itxnGroup.push(
     nodeFactory.aBICall({
-      target: target,
-      args: args,
+      target,
+      args,
       fields: mappedFields,
       sourceLocation,
       wtype: new wtypes.WABICallInnerTransactionFields({

--- a/src/awst_build/eb/arc4/c2c.ts
+++ b/src/awst_build/eb/arc4/c2c.ts
@@ -210,8 +210,7 @@ export class ContractProxyCallFunctionBuilder extends FunctionBuilder {
       `${this.functionType.name} is not an ABI method, or the containing contract has not been visited (possibly due to a circular reference)`,
       sourceLocation,
     )
-    const methodSelector =
-      arc4Config instanceof ARC4ABIMethodConfig ? buildArc4MethodConstant(this.functionType, arc4Config, sourceLocation) : null
+    const methodSelector = buildArc4MethodConstant(this.functionType, arc4Config, sourceLocation)
 
     return formatApplicationCallResponse({
       itxnResult: makeApplicationCall({
@@ -257,7 +256,6 @@ export function buildApplicationCallTxnFields({
   }
   // Add implicit fields
   if (applicationProxy) {
-    // Create a copy of the fields
     const implicitFields = getImplicitFields({ applicationProxy: applicationProxy, mappedFields, sourceLocation, methodConfig: arc4Config })
     // Only add fields that aren't explicitly provided
     for (const [key, expr] of implicitFields) {

--- a/src/awst_build/eb/arc4/c2c.ts
+++ b/src/awst_build/eb/arc4/c2c.ts
@@ -452,7 +452,11 @@ function getOca(
       ocaField.sourceLocation,
     )
     const oca = enumFromValue(Number(ocaField.value), OnCompletionAction)
-    codeInvariant(allowedCompletionTypes.includes(oca), `${txnFieldName.onCompletion} should be one of ${allowedCompletionTypes}`)
+    codeInvariant(
+      allowedCompletionTypes.includes(oca),
+      `${txnFieldName.onCompletion} should be one of ${allowedCompletionTypes}`,
+      ocaField.sourceLocation,
+    )
     return oca
   } else {
     const oca = allowedCompletionTypes[0]

--- a/src/awst_build/eb/arc4/c2c.ts
+++ b/src/awst_build/eb/arc4/c2c.ts
@@ -406,35 +406,15 @@ function getImplicitFields({
   }
   // Update or possible create
   if (oca === OnCompletionAction.UpdateApplication || !hasAppId) {
-    implicitFields.set(
-      TxnField.ApprovalProgramPages,
-      requireInstanceBuilder(applicationProxy.memberAccess('approvalProgram', sourceLocation)).resolve(),
-    )
-    implicitFields.set(
-      TxnField.ClearStateProgramPages,
-      requireInstanceBuilder(applicationProxy.memberAccess('clearStateProgram', sourceLocation)).resolve(),
-    )
+    const proxyField = (name: string) => requireInstanceBuilder(applicationProxy.memberAccess(name, sourceLocation)).resolve()
+    implicitFields.set(TxnField.ApprovalProgramPages, proxyField('approvalProgram'))
+    implicitFields.set(TxnField.ClearStateProgramPages, proxyField('clearStateProgram'))
     if (!hasAppId) {
-      implicitFields.set(
-        TxnField.GlobalNumUint,
-        requireInstanceBuilder(applicationProxy.memberAccess('globalUints', sourceLocation)).resolve(),
-      )
-      implicitFields.set(
-        TxnField.GlobalNumByteSlice,
-        requireInstanceBuilder(applicationProxy.memberAccess('globalBytes', sourceLocation)).resolve(),
-      )
-      implicitFields.set(
-        TxnField.LocalNumByteSlice,
-        requireInstanceBuilder(applicationProxy.memberAccess('localBytes', sourceLocation)).resolve(),
-      )
-      implicitFields.set(
-        TxnField.LocalNumUint,
-        requireInstanceBuilder(applicationProxy.memberAccess('localUints', sourceLocation)).resolve(),
-      )
-      implicitFields.set(
-        TxnField.ExtraProgramPages,
-        requireInstanceBuilder(applicationProxy.memberAccess('extraProgramPages', sourceLocation)).resolve(),
-      )
+      implicitFields.set(TxnField.GlobalNumUint, proxyField('globalUints'))
+      implicitFields.set(TxnField.GlobalNumByteSlice, proxyField('globalBytes'))
+      implicitFields.set(TxnField.LocalNumByteSlice, proxyField('localBytes'))
+      implicitFields.set(TxnField.LocalNumUint, proxyField('localUints'))
+      implicitFields.set(TxnField.ExtraProgramPages, proxyField('extraProgramPages'))
     }
   }
   return implicitFields

--- a/src/awst_build/eb/bytes-expression-builder.ts
+++ b/src/awst_build/eb/bytes-expression-builder.ts
@@ -128,7 +128,7 @@ export class BytesFunctionBuilder extends FunctionBuilder {
       }
     }
 
-    let toFixedStrategy: 'assert-length' | 'unsafe-cast' = 'assert-length'
+    let toFixedStrategy: ToFixedStrategy = 'assert-length'
     if ((!initialValue && args.length) || args.length > 1) {
       const { args: parsedArgs } = parseFunctionArgs({
         args: args,
@@ -142,7 +142,7 @@ export class BytesFunctionBuilder extends FunctionBuilder {
         ],
       })
       const { strategy } = parsedArgs.at(-1) as unknown as { length: NumericLiteralExpressionBuilder; strategy?: StringExpressionBuilder }
-      toFixedStrategy = strategy === undefined ? 'assert-length' : mapStringConstant(fixedConversionStrategyMap, strategy.resolve())
+      toFixedStrategy = parseToFixedStrategy(strategy)
     }
     if (!initialValue) {
       return empty
@@ -151,11 +151,11 @@ export class BytesFunctionBuilder extends FunctionBuilder {
     if (initialValue.ptype instanceof TransientType) {
       logger.error(initialValue.sourceLocation, initialValue.ptype.expressionMessage)
       bytesBuilder = empty
-    } else if (initialValue.ptype.equals(uint64PType)) {
-      bytesBuilder = initialValue.toBytes(sourceLocation)
-    } else if (initialValue.ptype.equals(biguintPType)) {
-      bytesBuilder = initialValue.toBytes(sourceLocation)
-    } else if (initialValue.ptype.equals(stringPType)) {
+    } else if (
+      initialValue.ptype.equals(uint64PType) ||
+      initialValue.ptype.equals(biguintPType) ||
+      initialValue.ptype.equals(stringPType)
+    ) {
       bytesBuilder = initialValue.toBytes(sourceLocation)
     } else if (initialValue.ptype.equals(bytesPType)) {
       bytesBuilder = initialValue
@@ -236,7 +236,7 @@ class FromEncodingBuilder extends FunctionBuilder {
         callLocation: sourceLocation,
         argSpec: (a) => [a.passthrough(), a.obj({ length: a.required(NumericLiteralPType), strategy: a.optional(stringPType) })],
       })
-      const toFixedStrategy = strategy === undefined ? 'assert-length' : mapStringConstant(fixedConversionStrategyMap, strategy.resolve())
+      const toFixedStrategy = parseToFixedStrategy(strategy)
       if (toFixedStrategy !== 'assert-length') {
         logger.error(sourceLocation, `Invalid strategy value of '${toFixedStrategy}'. Expected 'assert-length'`)
       }
@@ -409,7 +409,7 @@ export function bytesToFixed(
   builder: InstanceBuilder,
   fixedType: BytesPType,
   sourceLocation: SourceLocation,
-  strategy: 'assert-length' | 'unsafe-cast' = 'assert-length',
+  strategy: ToFixedStrategy,
 ): InstanceBuilder {
   invariant(fixedType.length !== null, 'Should only be called for bytes with a fixed length', sourceLocation)
 
@@ -470,9 +470,15 @@ export function bytesToFixed(
   )
 }
 
-const fixedConversionStrategyMap: Record<string, 'assert-length' | 'unsafe-cast'> = {
+type ToFixedStrategy = 'assert-length' | 'unsafe-cast'
+
+const fixedConversionStrategyMap: Record<ToFixedStrategy, ToFixedStrategy> = {
   'assert-length': 'assert-length',
   'unsafe-cast': 'unsafe-cast',
+}
+
+function parseToFixedStrategy(strategy: InstanceBuilder | undefined): ToFixedStrategy {
+  return strategy === undefined ? 'assert-length' : mapStringConstant(fixedConversionStrategyMap, strategy.resolve())
 }
 
 export class ToFixedLengthFunctionBuilder extends FunctionBuilder {
@@ -497,21 +503,10 @@ export class ToFixedLengthFunctionBuilder extends FunctionBuilder {
       ],
     })
     const sizeConst = requireIntegerConstant(length)
-    const parsedStrategy = strategy === undefined ? 'assert-length' : mapStringConstant(fixedConversionStrategyMap, strategy.resolve())
+    const parsedStrategy = parseToFixedStrategy(strategy)
     const ptype = new BytesPType({ length: sizeConst.value })
 
-    if (parsedStrategy === 'assert-length') {
-      return bytesToFixed(this.builder, ptype, sourceLocation)
-    } else {
-      return instanceEb(
-        nodeFactory.reinterpretCast({
-          expr: this.builder.resolve(),
-          wtype: ptype.wtype,
-          sourceLocation,
-        }),
-        ptype,
-      )
-    }
+    return bytesToFixed(this.builder, ptype, sourceLocation, parsedStrategy)
   }
 }
 

--- a/src/awst_build/eb/index.ts
+++ b/src/awst_build/eb/index.ts
@@ -263,10 +263,6 @@ export abstract class ClassBuilder extends NodeBuilder {
 export abstract class FunctionBuilder extends NodeBuilder {
   readonly ptype: PType | undefined = undefined
 
-  constructor(location: SourceLocation) {
-    super(location)
-  }
-
   abstract call(
     args: ReadonlyArray<NodeBuilder>,
     typeArgs: ReadonlyArray<PType>,
@@ -367,9 +363,6 @@ export function requireLValue(expr: awst.Expression): awst.LValue {
         sourceLocation: expr.sourceLocation,
       })
     }
-  }
-  if (expr instanceof awst.ReinterpretCast) {
-    requireLValue(expr.expr)
   }
   if (expr instanceof awst.TupleExpression) {
     for (const item of expr.items) {

--- a/src/awst_build/eb/util/array/concat.ts
+++ b/src/awst_build/eb/util/array/concat.ts
@@ -7,7 +7,7 @@ import { CodeError } from '../../../../errors'
 import { bigIntToUint8Array, codeInvariant } from '../../../../util'
 import type { PType } from '../../../ptypes'
 import { ArrayLiteralPType, ArrayPType, FixedArrayPType, MutableTuplePType, ReadonlyArrayPType, ReadonlyTuplePType } from '../../../ptypes'
-import { ARC4ArrayType, DynamicArrayType, DynamicBytesType, StaticArrayType, StaticBytesType } from '../../../ptypes/arc4-types'
+import { ARC4ArrayType, DynamicArrayType, dynamicBytesType, StaticArrayType, StaticBytesType } from '../../../ptypes/arc4-types'
 import { containsMutableType } from '../../../ptypes/visitors/contains-mutable-visitor'
 import { instanceEb } from '../../../type-registry'
 import type { InstanceBuilder } from '../../index'
@@ -24,7 +24,7 @@ export function concatArrays(left: InstanceBuilder, right: InstanceBuilder, sour
       TODO: This is only required because puya doesn't support staticarray + other => dynamic array
       To work around this, we convert arc4 static bytes and static array to dynamic bytes and dynamic array
      */
-    const dynamicType = left.ptype instanceof StaticBytesType ? DynamicBytesType : new DynamicArrayType({ ...left.ptype })
+    const dynamicType = left.ptype instanceof StaticBytesType ? dynamicBytesType : new DynamicArrayType({ ...left.ptype })
     return concatArrays(toArc4Dynamic(left.ptype.arraySize, left.resolve(), dynamicType), right, sourceLocation)
   } else if (left.ptype instanceof FixedArrayPType || left.ptype instanceof ReadonlyArrayPType) {
     /*
@@ -59,8 +59,8 @@ function getArrayConcatType(left: PType, right: PType, sourceLocation: SourceLoc
   if (left instanceof ARC4ArrayType) {
     if (right instanceof ARC4ArrayType) {
       sameElementType(left.elementType, right.elementType, sourceLocation)
-      if (left.equals(DynamicBytesType) || left instanceof StaticBytesType) {
-        return DynamicBytesType
+      if (left.equals(dynamicBytesType) || left instanceof StaticBytesType) {
+        return dynamicBytesType
       }
       return new DynamicArrayType({
         elementType: left.elementType,

--- a/src/awst_build/ptypes/arc4-types.ts
+++ b/src/awst_build/ptypes/arc4-types.ts
@@ -241,7 +241,7 @@ export const Arc4TupleGeneric = new GenericPType({
       return itemType
     })
     return new ARC4TupleType({
-      types: encodedTypes,
+      items: encodedTypes,
     })
   },
 })
@@ -257,14 +257,14 @@ export class ARC4TupleType extends ARC4EncodedType {
   readonly nativeType: ReadonlyTuplePType
   readonly abiTypeSignature: string
 
-  constructor({ types, sourceLocation }: { types: ARC4EncodedType[]; sourceLocation?: SourceLocation }) {
+  constructor({ items, sourceLocation }: { items: ARC4EncodedType[]; sourceLocation?: SourceLocation }) {
     super()
-    this.items = types
+    this.items = items
     this.name = `Tuple<${this.items.map((i) => i.name).join(',')}>`
     this.sourceLocation = sourceLocation
     this.nativeType = new ReadonlyTuplePType({ items: this.items })
 
-    this.abiTypeSignature = ARC4EncodedType.buildAbiTupleSignature(types)
+    this.abiTypeSignature = ARC4EncodedType.buildAbiTupleSignature(this.items)
   }
 
   get wtype(): wtypes.ARC4Tuple {
@@ -551,7 +551,7 @@ export const DynamicBytesConstructor = new LibClassType({
   name: 'DynamicBytes',
   module: Constants.moduleNames.algoTs.arc4.encodedTypes,
 })
-export const DynamicBytesType = new DynamicArrayType({
+export const dynamicBytesType = new DynamicArrayType({
   name: 'DynamicBytes',
   immutable: true,
   elementType: arc4ByteAlias,

--- a/src/awst_build/ptypes/arc4-types.ts
+++ b/src/awst_build/ptypes/arc4-types.ts
@@ -1,7 +1,7 @@
 import type { SourceLocation } from '../../awst/source-location'
 import { wtypes } from '../../awst/wtypes'
 import { Constants } from '../../constants'
-import { codeInvariant, invariant } from '../../util'
+import { codeInvariant } from '../../util'
 import type { PTypeField } from './base'
 import { GenericPType, PType } from './base'
 import {
@@ -237,7 +237,7 @@ export const Arc4TupleGeneric = new GenericPType({
       `${this.name} generic parameter must be a native tuple type`,
     )
     const encodedTypes = tupleType.items.map((itemType, index) => {
-      codeInvariant(itemType instanceof ARC4EncodedType, `Item ${index} of ARC4 Tuple must be an ARC4 encoded type`)
+      codeInvariant(itemType instanceof ARC4EncodedType, `Item ${index} of ${this.name} must be an ARC4 encoded type`)
       return itemType
     })
     return new ARC4TupleType({
@@ -283,11 +283,11 @@ export const UintNGeneric = new GenericPType({
   name: 'Uint',
   module: Constants.moduleNames.algoTs.arc4.encodedTypes,
   parameterise(typeArgs: readonly PType[]): UintNType {
-    codeInvariant(typeArgs.length === 1, 'UintNType type expects exactly one type parameter')
+    codeInvariant(typeArgs.length === 1, `${this.name} type expects exactly one type parameter`)
     const [size] = typeArgs
     codeInvariant(
       size instanceof NumericLiteralPType && size.literalValue,
-      `Generic type param for UintNType must be a literal number. Inferred type is ${size.name}`,
+      `Generic type param for ${this.name} must be a literal number. Inferred type is ${size.name}`,
     )
 
     return new UintNType({ n: size.literalValue })
@@ -329,11 +329,11 @@ export const UFixedNxMGeneric = new GenericPType({
     const [n, m] = typeArgs
     codeInvariant(
       n instanceof NumericLiteralPType && n.literalValue,
-      `Generic type param 'N' for ${this.name}  must be a literal number. Inferred type is ${n.name}`,
+      `Generic type param 'N' for ${this.name} must be a literal number. Inferred type is ${n.name}`,
     )
     codeInvariant(
       m instanceof NumericLiteralPType && m.literalValue,
-      `Generic type param 'M' for UintNType must be a literal number. Inferred type is ${m.name}`,
+      `Generic type param 'M' for ${this.name} must be a literal number. Inferred type is ${m.name}`,
     )
     return new UFixedNxMType({
       n: n.literalValue,
@@ -362,7 +362,7 @@ export class UFixedNxMType extends ARC4EncodedType {
     this.n = n
     this.m = m
 
-    this.name = `${UFixedNxMGeneric.name}<${n}, ${m}>`
+    this.name = `UFixed<${n}, ${m}>`
     this.wtype = new wtypes.ARC4UFixedNxM({ n: this.n, m: this.m })
     this.abiTypeSignature = `ufixed${n}x${m}`
   }
@@ -377,12 +377,12 @@ export const arc4ByteAlias = new UintNType({ n: 8n, wtype: wtypes.arc4ByteAliasW
 export const DynamicArrayGeneric = new GenericPType({
   name: 'DynamicArray',
   module: Constants.moduleNames.algoTs.arc4.encodedTypes,
-  parameterise: (typeArgs: readonly PType[]): DynamicArrayType => {
-    codeInvariant(typeArgs.length === 1, 'DynamicArray type expects exactly one type parameter')
+  parameterise(typeArgs: readonly PType[]): DynamicArrayType {
+    codeInvariant(typeArgs.length === 1, `${this.name} type expects exactly one type parameter`)
     const [elementType] = typeArgs
     codeInvariant(
       elementType instanceof ARC4EncodedType,
-      `Generic type param for DynamicArray must be an ARC4 encoded type. Inferred type is ${elementType.name}`,
+      `Generic type param for ${this.name} must be an ARC4 encoded type. Inferred type is ${elementType.name}`,
     )
 
     return new DynamicArrayType({ elementType: elementType })
@@ -436,16 +436,16 @@ export class DynamicArrayType extends ARC4ArrayType {
 export const StaticArrayGeneric = new GenericPType({
   name: 'StaticArray',
   module: Constants.moduleNames.algoTs.arc4.encodedTypes,
-  parameterise: (typeArgs: readonly PType[]): StaticArrayType => {
-    codeInvariant(typeArgs.length === 2, 'StaticArray type expects exactly one type parameters')
+  parameterise(typeArgs: readonly PType[]): StaticArrayType {
+    codeInvariant(typeArgs.length === 2, `${this.name} type expects exactly two type parameters`)
     const [elementType, arraySize] = typeArgs
     codeInvariant(
       elementType instanceof ARC4EncodedType,
-      `Element type generic type param for StaticArray must be an ARC4 encoded type. Inferred type is ${elementType.name}`,
+      `Element type generic type param for ${this.name} must be an ARC4 encoded type. Inferred type is ${elementType.name}`,
     )
     codeInvariant(
       arraySize instanceof NumericLiteralPType,
-      `Array size generic type param for StaticArray must be a literal number. Inferred type is ${arraySize.name}`,
+      `Array size generic type param for ${this.name} must be a literal number. Inferred type is ${arraySize.name}`,
     )
 
     return new StaticArrayType({ arraySize: arraySize.literalValue, elementType })
@@ -522,13 +522,13 @@ export const AddressClass = new LibClassType({
 export const StaticBytesGeneric = new GenericPType({
   name: 'StaticBytes',
   module: Constants.moduleNames.algoTs.arc4.encodedTypes,
-  parameterise: (typeArgs: readonly PType[]): StaticBytesType => {
-    codeInvariant(typeArgs.length === 1, 'StaticBytes type expects exactly one type parameter')
+  parameterise(typeArgs: readonly PType[]): StaticBytesType {
+    codeInvariant(typeArgs.length === 1, `${this.name} type expects exactly one type parameter`)
     const [length] = typeArgs
 
     codeInvariant(
       length instanceof NumericLiteralPType,
-      `Length generic type param for StaticBytes must be a literal number. Inferred type is ${length.name}`,
+      `Length generic type param for ${this.name} must be a literal number. Inferred type is ${length.name}`,
     )
     return new StaticBytesType({
       length: length.literalValue,
@@ -552,7 +552,7 @@ export const DynamicBytesConstructor = new LibClassType({
   module: Constants.moduleNames.algoTs.arc4.encodedTypes,
 })
 export const DynamicBytesType = new DynamicArrayType({
-  name: `DynamicBytes`,
+  name: 'DynamicBytes',
   immutable: true,
   elementType: arc4ByteAlias,
   nativeType: bytesPType,
@@ -595,9 +595,9 @@ export const ContractProxyGeneric = new GenericPType({
   name: 'ContractProxy',
   module: Constants.moduleNames.algoTs.arc4.c2c,
   parameterise(args: readonly PType[]) {
-    invariant(args.length === 1, 'ContractProxy expects exactly 1 type arg')
+    codeInvariant(args.length === 1, `${this.name} expects exactly 1 type arg`)
     const [typeArg] = args
-    invariant(typeArg instanceof ContractClassPType && typeArg.isARC4, 'Contract Proxy generic type arg must extend arc4 Contract type')
+    codeInvariant(typeArg instanceof ContractClassPType && typeArg.isARC4, `${this.name} generic type arg must extend arc4 Contract type`)
     return new ContractProxyType({ contractType: typeArg })
   },
 })
@@ -626,7 +626,7 @@ export const TypedApplicationCallResponseGeneric = new GenericPType({
   name: 'TypedApplicationCallResponse',
   module: Constants.moduleNames.algoTs.arc4.c2c,
   parameterise(args: readonly PType[]) {
-    invariant(args.length === 1, 'TypedApplicationCallResponse expects exactly 1 type arg')
+    codeInvariant(args.length === 1, `${this.name} expects exactly 1 type arg`)
     const [typeArg] = args
     return new TypedApplicationCallResponseType({ returnValue: typeArg })
   },

--- a/src/awst_build/ptypes/arc4-types.ts
+++ b/src/awst_build/ptypes/arc4-types.ts
@@ -57,7 +57,7 @@ export const UintN256Class = new LibClassType({
 })
 export abstract class ARC4EncodedType extends PType {
   abstract readonly wtype: wtypes.ARC4Type
-  abstract readonly nativeType: PType | undefined
+  abstract readonly nativeType: PType
   abstract readonly abiTypeSignature: string
 
   protected static buildAbiTupleSignature(types: ARC4EncodedType[]): string {

--- a/src/awst_build/ptypes/index.ts
+++ b/src/awst_build/ptypes/index.ts
@@ -221,7 +221,7 @@ export class IntersectionPType extends TransientType {
     const name = types.map((t) => t).join(' & ')
     super({
       name,
-      module: 'lib.d.ts',
+      module: Constants.moduleNames.tslib,
       singleton: false,
       typeMessage: transientTypeErrors.intersectionTypes(name).usedAsType,
       expressionMessage: transientTypeErrors.intersectionTypes(name).usedInExpression,
@@ -270,7 +270,7 @@ export class UnionPType extends TransientType {
     }
     super({
       name,
-      module: 'lib.d.ts',
+      module: Constants.moduleNames.tslib,
       singleton: false,
       typeMessage,
       expressionMessage,
@@ -522,7 +522,7 @@ export class InternalType extends PType {
   }
 }
 export const ClassMethodDecoratorContext = new InternalType({
-  module: 'typescript/lib/lib.decorators.d.ts',
+  module: Constants.moduleNames.typescript.decorators,
   name: 'ClassMethodDecoratorContext',
 })
 
@@ -532,7 +532,7 @@ export class AnyPType extends PType {
     throw new CodeError('`any` is not valid as a variable, parameter, return, or property type.')
   }
   readonly name = 'any'
-  readonly module = 'lib.d.ts'
+  readonly module = Constants.moduleNames.tslib
   readonly singleton = false
 
   accept<T>(visitor: PTypeVisitor<T>): T {
@@ -924,7 +924,7 @@ export const ReadonlyGeneric = new GenericPType({
 
 abstract class ObjectPType extends PType {
   readonly name: string
-  readonly module: string = 'lib.d.ts'
+  readonly module: string = Constants.moduleNames.tslib
   readonly alias: SymbolName | null
   readonly description: string | undefined
   readonly properties: PTypeField[]
@@ -1078,40 +1078,40 @@ export function isTupleLike(ptype: PTypeOrClass): ptype is MutableTuplePType | R
 
 export const voidPType = new ABICompatibleInstanceType({
   name: 'void',
-  module: 'lib.d.ts',
+  module: Constants.moduleNames.tslib,
   wtype: wtypes.voidWType,
   abiTypeSignature: 'void',
 })
 export const neverPType = new InstanceType({
   name: 'never',
-  module: 'lib.d.ts',
+  module: Constants.moduleNames.tslib,
   wtype: wtypes.voidWType,
 })
 export const unknownPType = new UnsupportedType({
   name: 'unknown',
-  module: 'lib.d.ts',
+  module: Constants.moduleNames.tslib,
   fullName: 'unknown',
 })
 
 export const esSymbol = new UnsupportedType({
   name: 'symbol',
-  module: 'lib.d.ts',
+  module: Constants.moduleNames.tslib,
   fullName: 'symbol',
 })
 
 export const nullPType = new UnsupportedType({
   name: 'null',
-  module: 'lib.d.ts',
+  module: Constants.moduleNames.tslib,
   fullName: 'null',
 })
 export const undefinedPType = new UnsupportedType({
   name: 'undefined',
-  module: 'lib.d.ts',
+  module: Constants.moduleNames.tslib,
   fullName: 'undefined',
 })
 export const PromiseGeneric = new GenericPType({
   name: 'Promise',
-  module: 'typescript/lib/lib.es5.d.ts',
+  module: Constants.moduleNames.typescript.es5,
   parameterise(ptypes: readonly PType[]) {
     codeInvariant(ptypes.length === 1, 'Promise expects exactly 1 generic parameter')
     return new PromiseType({ resolveType: ptypes[0] })
@@ -1122,7 +1122,7 @@ export class PromiseType extends UnsupportedType {
   constructor({ resolveType }: { resolveType: PType }) {
     super({
       name: 'Promise',
-      module: 'typescript/lib/lib.es5.d.ts',
+      module: Constants.moduleNames.typescript.es5,
     })
     this.resolveType = resolveType
   }
@@ -1131,13 +1131,13 @@ export const anyPType = new AnyPType()
 
 export const boolPType = new InstanceType({
   name: 'boolean',
-  module: 'lib.d.ts',
+  module: Constants.moduleNames.tslib,
   wtype: wtypes.boolWType,
 })
 
 export const BooleanFunction = new LibFunctionType({
   name: 'Boolean',
-  module: 'typescript/lib/lib.es5.d.ts',
+  module: Constants.moduleNames.typescript.es5,
 })
 
 export class BigIntPType extends TransientType {
@@ -1150,7 +1150,7 @@ export class NumberPType extends TransientType {
 
 export const bigIntPType = new BigIntPType({
   name: 'bigint',
-  module: 'lib.d.ts',
+  module: Constants.moduleNames.tslib,
   singleton: false,
   typeMessage: transientTypeErrors.nativeNumeric('bigint').usedAsType,
   expressionMessage: transientTypeErrors.nativeNumeric('bigint').usedInExpression,
@@ -1158,12 +1158,12 @@ export const bigIntPType = new BigIntPType({
 
 export const stringPType = new InstanceType({
   name: 'string',
-  module: 'lib.d.ts',
+  module: Constants.moduleNames.tslib,
   wtype: wtypes.stringWType,
 })
 export const StringFunction = new LibFunctionType({
   name: 'String',
-  module: 'typescript/lib/lib.es5.d.ts',
+  module: Constants.moduleNames.typescript.es5,
 })
 
 export const uint64PType = new InstanceType({
@@ -1182,7 +1182,7 @@ export class NumericLiteralPType extends TransientType {
   constructor({ literalValue }: { literalValue: bigint }) {
     super({
       name: `${literalValue}`,
-      module: 'lib.d.ts',
+      module: Constants.moduleNames.tslib,
       singleton: false,
       typeMessage: transientTypeErrors.nativeNumeric(literalValue.toString()).usedAsType,
       expressionMessage: transientTypeErrors.nativeNumeric(literalValue.toString()).usedInExpression,
@@ -1198,7 +1198,7 @@ export class BigIntLiteralPType extends TransientType {
   constructor({ literalValue }: { literalValue: bigint }) {
     super({
       name: `${literalValue}n`,
-      module: 'lib.d.ts',
+      module: Constants.moduleNames.tslib,
       singleton: false,
       typeMessage: transientTypeErrors.nativeNumeric(`${literalValue}n`).usedAsType,
       expressionMessage: transientTypeErrors.nativeNumeric(`${literalValue}n`).usedInExpression,
@@ -1210,7 +1210,7 @@ export class BigIntLiteralPType extends TransientType {
 }
 export const numberPType = new NumberPType({
   name: 'number',
-  module: 'lib.d.ts',
+  module: Constants.moduleNames.tslib,
   singleton: false,
   typeMessage: transientTypeErrors.nativeNumeric('number').usedAsType,
   expressionMessage: transientTypeErrors.nativeNumeric('number').usedInExpression,
@@ -1370,7 +1370,7 @@ export const arc4BaseContractType = new BaseContractClassType({
   sourceLocation: SourceLocation.None,
 })
 export const itoaMethod = new LibFunctionType({
-  module: 'puya-ts',
+  module: Constants.moduleNames.puyaTs,
   name: 'itoa',
 })
 export const arc4BareMethodDecorator = new LibFunctionType({
@@ -1617,7 +1617,7 @@ export const urangeFunction = new LibFunctionType({
 })
 export const IterableIteratorGeneric = new GenericPType({
   name: 'IterableIterator',
-  module: 'typescript/lib/lib.es2015.iterable.d.ts',
+  module: Constants.moduleNames.typescript.iterable,
   parameterise(typeArgs: readonly PType[]): IterableIteratorType {
     codeInvariant(typeArgs.length >= 1 && typeArgs.length <= 3, 'IterableIterator type expects 1-3 type parameters')
     // Currently ignoring return and next types
@@ -1633,7 +1633,7 @@ export class IterableIteratorType extends TransientType {
   constructor({ itemType }: { itemType: PType }) {
     super({
       name: `IterableIterator<${itemType.name}>`,
-      module: 'typescript/lib/lib.es2015.iterable.d.ts',
+      module: Constants.moduleNames.typescript.iterable,
       typeMessage: '`IterableIterator` is not valid as a variable, parameter, return, or property type. ',
       expressionMessage: 'IterableIterator expressions can only be used in for loops',
       singleton: false,
@@ -1652,7 +1652,7 @@ export class IterableIteratorType extends TransientType {
 
 export const GeneratorGeneric = new GenericPType({
   name: 'Generator',
-  module: 'typescript/lib/lib.es2015.generator.d.ts',
+  module: Constants.moduleNames.typescript.generator,
   parameterise(ptypes) {
     codeInvariant(ptypes.length === 3, 'Generator type expects exactly 3 type params')
 
@@ -1672,7 +1672,7 @@ export class GeneratorType extends UnsupportedType {
   constructor({ itemType, returnType, nextType }: { itemType: PType; returnType: PType; nextType: PType }) {
     super({
       name: 'Generator',
-      module: 'typescript/lib/lib.es2015.generator.d.ts',
+      module: Constants.moduleNames.typescript.generator,
     })
     this.itemType = itemType
     this.returnType = returnType

--- a/src/awst_build/ptypes/index.ts
+++ b/src/awst_build/ptypes/index.ts
@@ -675,7 +675,7 @@ export class FunctionPType extends PType {
   readonly name: string
   readonly module: string
   readonly returnType: PType
-  readonly parameters: Array<readonly [string, PType]>
+  readonly parameters: ReadonlyArray<readonly [string, PType]>
   readonly singleton = true
   readonly sourceLocation: SourceLocation | undefined
   readonly declaredIn: SymbolName | undefined
@@ -684,7 +684,7 @@ export class FunctionPType extends PType {
     name: string
     module: string
     returnType: PType
-    parameters: Array<readonly [string, PType]>
+    parameters: ReadonlyArray<readonly [string, PType]>
     sourceLocation: SourceLocation | undefined
     declaredIn?: SymbolName
   }) {

--- a/src/awst_build/ptypes/index.ts
+++ b/src/awst_build/ptypes/index.ts
@@ -325,7 +325,7 @@ export const GlobalStateGeneric = new GenericPType({
   name: 'GlobalState',
   module: Constants.moduleNames.algoTs.state,
   parameterise(typeArgs: readonly PType[]): GlobalStateType {
-    codeInvariant(typeArgs.length === 1, 'GlobalState type expects exactly one type parameter')
+    codeInvariant(typeArgs.length === 1, `${this.name} type expects exactly one type parameter`)
     return new GlobalStateType({
       content: typeArgs[0],
     })
@@ -385,7 +385,7 @@ export const LocalStateGeneric = new GenericPType({
   name: 'LocalState',
   module: Constants.moduleNames.algoTs.state,
   parameterise(typeArgs: readonly PType[]): LocalStateType {
-    codeInvariant(typeArgs.length === 1, 'LocalState type expects exactly one type parameter')
+    codeInvariant(typeArgs.length === 1, `${this.name} type expects exactly one type parameter`)
     return new LocalStateType({
       content: typeArgs[0],
     })
@@ -806,7 +806,7 @@ export const ArrayGeneric = new GenericPType({
   name: 'Array',
   module: Constants.moduleNames.typescript.es5,
   parameterise(typeArgs) {
-    codeInvariant(typeArgs.length === 1, 'Array expects exactly 1 type argument')
+    codeInvariant(typeArgs.length === 1, `${this.name} expects exactly 1 type argument`)
     return new ArrayPType({ elementType: typeArgs[0] })
   },
 })
@@ -851,7 +851,7 @@ export const ReadonlyArrayGeneric = new GenericPType({
   name: 'ReadonlyArray',
   module: Constants.moduleNames.typescript.es5,
   parameterise(typeArgs) {
-    codeInvariant(typeArgs.length === 1, 'ReadonlyArray expects exactly 1 type argument')
+    codeInvariant(typeArgs.length === 1, `${this.name} expects exactly 1 type argument`)
     return new ReadonlyArrayPType({ elementType: typeArgs[0] })
   },
 })
@@ -870,11 +870,11 @@ export const FixedArrayGeneric = new GenericPType({
   name: 'FixedArray',
   module: Constants.moduleNames.algoTs.arrays,
   parameterise(typeArgs) {
-    codeInvariant(typeArgs.length === 2, 'FixedArray type expects exactly one type parameters')
+    codeInvariant(typeArgs.length === 2, `${this.name} type expects exactly two type parameters`)
     const [elementType, arraySize] = typeArgs
     codeInvariant(
       arraySize instanceof NumericLiteralPType,
-      `Array size generic type param for FixedArray must be a literal number. Inferred type is ${arraySize.name}`,
+      `Array size generic type param for ${this.name} must be a literal number. Inferred type is ${arraySize.name}`,
     )
     if (elementType instanceof TransientType) {
       throw new CodeError(elementType.typeMessage)
@@ -916,7 +916,10 @@ export const ReadonlyGeneric = new GenericPType({
   name: 'Readonly',
   module: Constants.moduleNames.typescript.es5,
   parameterise([obj, ...rest]) {
-    codeInvariant(obj instanceof MutableObjectPType && !rest.length, 'Readonly expects exactly 1 generic type arg that is an object type')
+    codeInvariant(
+      obj instanceof MutableObjectPType && !rest.length,
+      `${this.name} expects exactly 1 generic type arg that is an object type`,
+    )
 
     return obj.toImmutable()
   },
@@ -1113,7 +1116,7 @@ export const PromiseGeneric = new GenericPType({
   name: 'Promise',
   module: Constants.moduleNames.typescript.es5,
   parameterise(ptypes: readonly PType[]) {
-    codeInvariant(ptypes.length === 1, 'Promise expects exactly 1 generic parameter')
+    codeInvariant(ptypes.length === 1, `${this.name} expects exactly 1 generic parameter`)
     return new PromiseType({ resolveType: ptypes[0] })
   },
 })
@@ -1634,7 +1637,7 @@ export class IterableIteratorType extends TransientType {
     super({
       name: `IterableIterator<${itemType.name}>`,
       module: Constants.moduleNames.typescript.iterable,
-      typeMessage: '`IterableIterator` is not valid as a variable, parameter, return, or property type. ',
+      typeMessage: '`IterableIterator` is not valid as a variable, parameter, return, or property type',
       expressionMessage: 'IterableIterator expressions can only be used in for loops',
       singleton: false,
     })
@@ -1654,7 +1657,7 @@ export const GeneratorGeneric = new GenericPType({
   name: 'Generator',
   module: Constants.moduleNames.typescript.generator,
   parameterise(ptypes) {
-    codeInvariant(ptypes.length === 3, 'Generator type expects exactly 3 type params')
+    codeInvariant(ptypes.length === 3, `${this.name} type expects exactly 3 type params`)
 
     const [itemType, returnType, nextType] = ptypes
     return new GeneratorType({
@@ -1860,7 +1863,7 @@ export const compiledLogicSigType = new ImmutableObjectPType({
     name: 'CompiledLogicSig',
     module: Constants.moduleNames.algoTs.compiled,
   }),
-  description: 'Provides account for a Logic Signature. Created by calling `compile(LogicSigType)``',
+  description: 'Provides account for a Logic Signature. Created by calling `compile(LogicSigType)`',
   properties: [{ name: 'account', ptype: accountPType, description: null }],
 })
 
@@ -1903,8 +1906,8 @@ export const PolytypeClassMethodHelper = new LibFunctionType({
 export const ReferenceArrayGeneric = new GenericPType({
   name: 'ReferenceArray',
   module: Constants.moduleNames.algoTs.referenceArray,
-  parameterise: (typeArgs: readonly PType[]): ReferenceArrayType => {
-    codeInvariant(typeArgs.length === 1, 'ReferenceArray type expects exactly one type parameter')
+  parameterise(typeArgs: readonly PType[]): ReferenceArrayType {
+    codeInvariant(typeArgs.length === 1, `${this.name} type expects exactly one type parameter`)
     const [elementType] = typeArgs
 
     return new ReferenceArrayType({ elementType: elementType })

--- a/src/awst_build/ptypes/index.ts
+++ b/src/awst_build/ptypes/index.ts
@@ -303,6 +303,24 @@ abstract class StorageProxyPType extends PType {
     this.contentType = props.content
   }
 }
+
+abstract class StateProxyPType extends StorageProxyPType {
+  readonly module: string
+  readonly kind: string
+
+  protected constructor(props: { content: PType; kind: string }) {
+    super({ content: props.content, keyWType: wtypes.stateKeyWType })
+    this.module = Constants.moduleNames.algoTs.state
+    this.kind = props.kind
+  }
+
+  get name() {
+    return `${this.kind}<${this.contentType.name}>`
+  }
+  get fullName() {
+    return `${this.module}::${this.kind}<${this.contentType.fullName}>`
+  }
+}
 export const GlobalStateGeneric = new GenericPType({
   name: 'GlobalState',
   module: Constants.moduleNames.algoTs.state,
@@ -313,23 +331,33 @@ export const GlobalStateGeneric = new GenericPType({
     })
   },
 })
-export class GlobalStateType extends StorageProxyPType {
+export class GlobalStateType extends StateProxyPType {
   readonly [PType.IdSymbol] = 'GlobalStateType'
-  static readonly baseName = 'GlobalState'
-  static readonly baseFullName = `${Constants.moduleNames.algoTs.state}::${GlobalStateType.baseName}`
-  readonly module: string = Constants.moduleNames.algoTs.state
-  get name() {
-    return `${GlobalStateType.baseName}<${this.contentType.name}>`
-  }
-  get fullName() {
-    return `${GlobalStateType.baseFullName}<${this.contentType.fullName}>`
-  }
   constructor(props: { content: PType }) {
-    super({ ...props, keyWType: wtypes.stateKeyWType })
+    super({ ...props, kind: 'GlobalState' })
   }
 
   accept<T>(visitor: PTypeVisitor<T>): T {
     return visitor.visitGlobalStateType(this)
+  }
+}
+abstract class StateMapProxyPType extends StorageProxyPType {
+  readonly module: string
+  readonly kind: string
+  readonly keyType: PType
+
+  protected constructor(props: { content: PType; keyType: PType; kind: string }) {
+    super({ content: props.content, keyWType: wtypes.stateKeyWType })
+    this.module = Constants.moduleNames.algoTs.state
+    this.kind = props.kind
+    this.keyType = props.keyType
+  }
+
+  get name() {
+    return `${this.kind}<${this.keyType.name}, ${this.contentType.name}>`
+  }
+  get fullName() {
+    return `${this.module}::${this.name}<${this.keyType.name}, ${this.contentType.fullName}>`
   }
 }
 export const GlobalMapGeneric = new GenericPType({
@@ -343,19 +371,10 @@ export const GlobalMapGeneric = new GenericPType({
     })
   },
 })
-export class GlobalMapType extends StorageProxyPType {
+export class GlobalMapType extends StateMapProxyPType {
   readonly [PType.IdSymbol] = 'GlobalMapType'
-  readonly module: string = Constants.moduleNames.algoTs.state
-  get name() {
-    return `GlobalMap<${this.keyType.name}, ${this.contentType.name}>`
-  }
-  get fullName() {
-    return `${this.module}::${this.name}<${this.keyType.name}, ${this.contentType.fullName}>`
-  }
-  readonly keyType: PType
   constructor(props: { content: PType; keyType: PType }) {
-    super({ ...props, keyWType: wtypes.stateKeyWType })
-    this.keyType = props.keyType
+    super({ ...props, kind: 'GlobalMap' })
   }
 
   accept<T>(visitor: PTypeVisitor<T>): T {
@@ -372,25 +391,10 @@ export const LocalStateGeneric = new GenericPType({
     })
   },
 })
-export class LocalStateType extends StorageProxyPType {
+export class LocalStateType extends StateProxyPType {
   readonly [PType.IdSymbol] = 'LocalStateType'
-  static readonly baseName = 'LocalState'
-  static readonly baseFullName = `${Constants.moduleNames.algoTs.state}::${LocalStateType.baseName}`
-  readonly module: string = Constants.moduleNames.algoTs.state
-  get name() {
-    return `${LocalStateType.baseName}<${this.contentType.name}>`
-  }
-  get fullName() {
-    return `${LocalStateType.baseFullName}<${this.contentType.fullName}>`
-  }
   constructor(props: { content: PType }) {
-    super({ ...props, keyWType: wtypes.stateKeyWType })
-  }
-  static parameterise(typeArgs: PType[]): LocalStateType {
-    codeInvariant(typeArgs.length === 1, 'LocalState type expects exactly one type parameter')
-    return new LocalStateType({
-      content: typeArgs[0],
-    })
+    super({ ...props, kind: 'LocalState' })
   }
 
   accept<T>(visitor: PTypeVisitor<T>): T {
@@ -408,19 +412,10 @@ export const LocalMapGeneric = new GenericPType({
     })
   },
 })
-export class LocalMapType extends StorageProxyPType {
+export class LocalMapType extends StateMapProxyPType {
   readonly [PType.IdSymbol] = 'LocalMapType'
-  readonly module: string = Constants.moduleNames.algoTs.state
-  get name() {
-    return `LocalMap<${this.keyType.name}, ${this.contentType.name}>`
-  }
-  get fullName() {
-    return `${this.module}::${this.name}<${this.keyType.name}, ${this.contentType.fullName}>`
-  }
-  readonly keyType: PType
   constructor(props: { content: PType; keyType: PType }) {
-    super({ ...props, keyWType: wtypes.stateKeyWType })
-    this.keyType = props.keyType
+    super({ ...props, kind: 'LocalMap' })
   }
 
   accept<T>(visitor: PTypeVisitor<T>): T {
@@ -572,8 +567,7 @@ export class ABICompatibleInstanceType extends InstanceType implements ABICompat
   }
 }
 
-export class LibFunctionType extends PType {
-  readonly [PType.IdSymbol] = 'LibFunctionType'
+abstract class LibPType extends PType {
   readonly wtype: undefined
   readonly name: string
   readonly module: string
@@ -584,106 +578,61 @@ export class LibFunctionType extends PType {
     this.name = name
     this.module = module
   }
-
+}
+export class LibFunctionType extends LibPType {
+  readonly [PType.IdSymbol] = 'LibFunctionType'
   accept<T>(visitor: PTypeVisitor<T>): T {
     return visitor.visitLibFunctionType(this)
   }
 }
-export class LibClassType extends PType {
+export class LibClassType extends LibPType {
   readonly [PType.IdSymbol] = 'LibClassType'
-  readonly wtype: undefined
-  readonly name: string
-  readonly module: string
-  readonly singleton = true
-
-  constructor({ name, module }: { name: string; module: string }) {
-    super()
-    this.name = name
-    this.module = module
-  }
-
   accept<T>(visitor: PTypeVisitor<T>): T {
     return visitor.visitLibClassType(this)
   }
 }
-export class LibObjType extends PType {
+export class LibObjType extends LibPType {
   readonly [PType.IdSymbol] = 'LibObjType'
-  readonly wtype: undefined
-  readonly name: string
-  readonly module: string
-  readonly singleton = true
-
-  constructor({ name, module }: { name: string; module: string }) {
-    super()
-    this.name = name
-    this.module = module
-  }
-
   accept<T>(visitor: PTypeVisitor<T>): T {
     return visitor.visitLibObjType(this)
   }
 }
 
-export class IntrinsicFunctionGroupType extends PType {
-  readonly [PType.IdSymbol] = 'IntrinsicFunctionGroupType'
+abstract class IntrinsicOpPType extends PType {
   readonly wtype: undefined
   readonly name: string
   readonly module: string = Constants.moduleNames.algoTs.op
-  readonly singleton = true
+  abstract readonly singleton: boolean
 
   constructor({ name }: { name: string }) {
     super()
     this.name = name
   }
-
+}
+export class IntrinsicFunctionGroupType extends IntrinsicOpPType {
+  readonly [PType.IdSymbol] = 'IntrinsicFunctionGroupType'
+  readonly singleton = true
   accept<T>(visitor: PTypeVisitor<T>): T {
     return visitor.visitIntrinsicFunctionGroupType(this)
   }
 }
-export class IntrinsicFunctionGroupTypeType extends PType {
+export class IntrinsicFunctionGroupTypeType extends IntrinsicOpPType {
   readonly [PType.IdSymbol] = 'IntrinsicFunctionGroupTypeType'
-  readonly wtype: undefined
-  readonly name: string
-  readonly module: string = Constants.moduleNames.algoTs.op
   readonly singleton = false
-
-  constructor({ name }: { name: string }) {
-    super()
-    this.name = name
-  }
-
   accept<T>(visitor: PTypeVisitor<T>): T {
     return visitor.visitIntrinsicFunctionGroupTypeType(this)
   }
 }
-export class IntrinsicFunctionType extends PType {
+export class IntrinsicFunctionType extends IntrinsicOpPType {
   readonly [PType.IdSymbol] = 'IntrinsicFunctionType'
-  readonly wtype: undefined
-  readonly name: string
-  readonly module: string = Constants.moduleNames.algoTs.op
   readonly singleton = true
-
-  constructor({ name }: { name: string }) {
-    super()
-    this.name = name
-  }
-
   accept<T>(visitor: PTypeVisitor<T>): T {
     return visitor.visitIntrinsicFunctionType(this)
   }
 }
-export class IntrinsicFunctionTypeType extends PType {
+export class IntrinsicFunctionTypeType extends IntrinsicOpPType {
   readonly [PType.IdSymbol] = 'IntrinsicFunctionTypeType'
-  readonly wtype: undefined
-  readonly name: string
-  readonly module: string = Constants.moduleNames.algoTs.op
   readonly singleton = false
-
-  constructor({ name }: { name: string }) {
-    super()
-    this.name = name
-  }
-
   accept<T>(visitor: PTypeVisitor<T>): T {
     return visitor.visitIntrinsicFunctionTypeType(this)
   }
@@ -800,22 +749,30 @@ export class ArrayLiteralPType extends PType {
   }
 }
 
-export class MutableTuplePType extends PType {
-  readonly [PType.IdSymbol] = 'MutableTuplePType'
-  readonly module: string = 'lib.d.ts'
-
-  get name() {
-    return `[${this.items.map((i) => i.name).join(', ')}]`
-  }
-  get fullName() {
-    return `${this.module}::[${this.items.map((i) => i.fullName).join(', ')}]`
-  }
-
+abstract class TupleBasePType extends PType {
   readonly items: PType[]
   readonly singleton = false
-  constructor(props: { items: PType[] }) {
+  readonly module: string = Constants.moduleNames.tslib
+  readonly namePrefix: '' | 'readonly '
+
+  protected constructor(props: { items: PType[]; namePrefix?: 'readonly ' }) {
     super()
     this.items = props.items
+    this.namePrefix = props.namePrefix ?? ''
+  }
+
+  get name() {
+    return `${this.namePrefix}[${this.items.map((i) => i.name).join(', ')}]`
+  }
+  get fullName() {
+    return `${this.module}::${this.namePrefix}[${this.items.map((i) => i.fullName).join(', ')}]`
+  }
+}
+
+export class MutableTuplePType extends TupleBasePType {
+  readonly [PType.IdSymbol] = 'MutableTuplePType'
+  constructor(props: { items: PType[] }) {
+    super(props)
   }
 
   get wtype(): wtypes.ARC4Tuple {
@@ -829,22 +786,10 @@ export class MutableTuplePType extends PType {
     return visitor.visitMutableTuplePType(this)
   }
 }
-export class ReadonlyTuplePType extends PType {
+export class ReadonlyTuplePType extends TupleBasePType {
   readonly [PType.IdSymbol] = 'ReadonlyTuplePType'
-  readonly module: string = 'lib.d.ts'
-
-  get name() {
-    return `readonly [${this.items.map((i) => i.name).join(', ')}]`
-  }
-  get fullName() {
-    return `${this.module}::readonly [${this.items.map((i) => i.fullName).join(', ')}]`
-  }
-
-  readonly items: PType[]
-  readonly singleton = false
   constructor(props: { items: PType[] }) {
-    super()
-    this.items = props.items
+    super({ ...props, namePrefix: 'readonly ' })
   }
 
   get wtype(): wtypes.WTuple {
@@ -865,20 +810,24 @@ export const ArrayGeneric = new GenericPType({
     return new ArrayPType({ elementType: typeArgs[0] })
   },
 })
-export class ArrayPType extends PType {
-  readonly [PType.IdSymbol] = 'ArrayPType'
+abstract class DynamicArrayBasePType extends PType {
   readonly elementType: PType
-  readonly immutable = false
+  readonly immutable: boolean
   readonly singleton = false
   readonly name: string
   readonly module: string = Constants.moduleNames.typescript.es5
-  get fullName() {
-    return `${this.module}::Array<${this.elementType.fullName}>`
-  }
-  constructor(props: { elementType: PType }) {
+  readonly kind: 'Array' | 'ReadonlyArray'
+
+  protected constructor(props: { elementType: PType; kind: 'Array' | 'ReadonlyArray'; immutable: boolean }) {
     super()
-    this.name = `Array<${props.elementType.name}>`
     this.elementType = props.elementType
+    this.immutable = props.immutable
+    this.kind = props.kind
+    this.name = `${props.kind}<${props.elementType.name}>`
+  }
+
+  get fullName() {
+    return `${this.module}::${this.kind}<${this.elementType.fullName}>`
   }
 
   get wtype() {
@@ -886,6 +835,12 @@ export class ArrayPType extends PType {
       elementType: this.elementType.wtypeOrThrow,
       immutable: this.immutable,
     })
+  }
+}
+export class ArrayPType extends DynamicArrayBasePType {
+  readonly [PType.IdSymbol] = 'ArrayPType'
+  constructor(props: { elementType: PType }) {
+    super({ ...props, kind: 'Array', immutable: false })
   }
 
   accept<T>(visitor: PTypeVisitor<T>): T {
@@ -900,27 +855,10 @@ export const ReadonlyArrayGeneric = new GenericPType({
     return new ReadonlyArrayPType({ elementType: typeArgs[0] })
   },
 })
-export class ReadonlyArrayPType extends PType {
+export class ReadonlyArrayPType extends DynamicArrayBasePType {
   readonly [PType.IdSymbol] = 'ReadonlyArrayPType'
-  readonly elementType: PType
-  readonly singleton = false
-  readonly immutable = true
-  readonly name: string
-  readonly module: string = Constants.moduleNames.typescript.es5
-  get fullName() {
-    return `${this.module}::ReadonlyArray<${this.elementType.fullName}>`
-  }
   constructor(props: { elementType: PType }) {
-    super()
-    this.elementType = props.elementType
-    this.name = `ReadonlyArray<${props.elementType.name}>`
-  }
-
-  get wtype() {
-    return new wtypes.ARC4DynamicArray({
-      elementType: this.elementType.wtypeOrThrow,
-      immutable: this.immutable,
-    })
+    super({ ...props, kind: 'ReadonlyArray', immutable: true })
   }
 
   accept<T>(visitor: PTypeVisitor<T>): T {
@@ -1019,6 +957,23 @@ abstract class ObjectPType extends PType {
   hasSameStructure(other: ObjectPType): boolean {
     return zipStrict(this.properties, other.properties).every(([left, right]) => left.name === right.name && left.ptype.equals(right.ptype))
   }
+
+  protected toWTuple(fallbackName: string): wtypes.WTuple {
+    const tupleTypes: wtypes.WType[] = []
+    const tupleNames: string[] = []
+    for (const { name, ptype } of this.properties) {
+      if (ptype instanceof TransientType) {
+        throw new CodeError(`Property '${name}' of ${this.name} has an unsupported type: ${ptype.typeMessage}`)
+      }
+      tupleTypes.push(ptype.wtypeOrThrow)
+      tupleNames.push(name)
+    }
+    return new wtypes.WTuple({
+      name: this.alias?.fullName ?? fallbackName,
+      names: tupleNames,
+      types: tupleTypes,
+    })
+  }
 }
 
 export class ObjectLiteralPType extends ObjectPType {
@@ -1052,20 +1007,7 @@ export class ObjectLiteralPType extends ObjectPType {
   }
 
   get wtype(): wtypes.WTuple {
-    const tupleTypes: wtypes.WType[] = []
-    const tupleNames: string[] = []
-    for (const { name, ptype } of this.properties) {
-      if (ptype instanceof TransientType) {
-        throw new CodeError(`Property '${name}' of ${this.name} has an unsupported type: ${ptype.typeMessage}`)
-      }
-      tupleTypes.push(ptype.wtypeOrThrow)
-      tupleNames.push(name)
-    }
-    return new wtypes.WTuple({
-      name: this.alias?.fullName ?? this.toString(),
-      names: tupleNames,
-      types: tupleTypes,
-    })
+    return this.toWTuple(this.toString())
   }
 }
 
@@ -1081,20 +1023,7 @@ export class ImmutableObjectPType extends ObjectPType {
   }
 
   get wtype(): wtypes.WTuple {
-    const tupleTypes: wtypes.WType[] = []
-    const tupleNames: string[] = []
-    for (const { name, ptype } of this.properties) {
-      if (ptype instanceof TransientType) {
-        throw new CodeError(`Property '${name}' of ${this.name} has an unsupported type: ${ptype.typeMessage}`)
-      }
-      tupleTypes.push(ptype.wtypeOrThrow)
-      tupleNames.push(name)
-    }
-    return new wtypes.WTuple({
-      name: this.alias?.fullName ?? this.name,
-      names: tupleNames,
-      types: tupleTypes,
-    })
+    return this.toWTuple(this.name)
   }
 
   accept<T>(visitor: PTypeVisitor<T>): T {

--- a/src/awst_build/ptypes/index.ts
+++ b/src/awst_build/ptypes/index.ts
@@ -1918,16 +1918,7 @@ export class ReferenceArrayType extends PType {
   readonly sourceLocation: SourceLocation | undefined
   readonly elementType: PType
 
-  constructor({
-    elementType,
-    sourceLocation,
-    name,
-  }: {
-    elementType: PType
-    sourceLocation?: SourceLocation
-    name?: string
-    immutable?: boolean
-  }) {
+  constructor({ elementType, sourceLocation, name }: { elementType: PType; sourceLocation?: SourceLocation; name?: string }) {
     super()
     this.name = name ?? `ReferenceArray<${elementType}>`
     this.sourceLocation = sourceLocation
@@ -1938,7 +1929,6 @@ export class ReferenceArrayType extends PType {
     return new wtypes.ReferenceArray({
       itemType: this.elementType.wtypeOrThrow,
       sourceLocation: this.sourceLocation,
-      immutable: false,
     })
   }
   accept<T>(visitor: PTypeVisitor<T>): T {

--- a/src/awst_build/ptypes/index.ts
+++ b/src/awst_build/ptypes/index.ts
@@ -1328,7 +1328,7 @@ export const applicationPType = new ABICompatibleInstanceType({
   module: Constants.moduleNames.algoTs.reference,
   abiTypeSignature: 'application',
 })
-export const ApplicationFunctionType = new LibFunctionType({
+export const ApplicationFunction = new LibFunctionType({
   name: 'Application',
   module: Constants.moduleNames.algoTs.reference,
 })

--- a/src/awst_build/ptypes/register.ts
+++ b/src/awst_build/ptypes/register.ts
@@ -114,7 +114,7 @@ import {
   DynamicArrayGeneric,
   DynamicArrayType,
   DynamicBytesConstructor,
-  DynamicBytesType,
+  dynamicBytesType,
   encodeArc4Function,
   methodSelectorFunction,
   sizeOfFunction,
@@ -140,7 +140,7 @@ import {
   applicationCallGtxnType,
   applicationCallItxnFn,
   applicationCallItxnParamsType,
-  ApplicationFunctionType,
+  ApplicationFunction,
   applicationItxnType,
   applicationPType,
   ApplicationTxnFunction,
@@ -433,7 +433,7 @@ export function registerPTypes(typeRegistry: TypeRegistry) {
   })
 
   // Reference types
-  typeRegistry.register({ ptype: ApplicationFunctionType, singletonEb: ApplicationFunctionBuilder })
+  typeRegistry.register({ ptype: ApplicationFunction, singletonEb: ApplicationFunctionBuilder })
   typeRegistry.register({ ptype: applicationPType, instanceEb: ApplicationExpressionBuilder })
   typeRegistry.register({ ptype: AccountFunction, singletonEb: AccountFunctionBuilder })
   typeRegistry.register({ ptype: accountPType, instanceEb: AccountExpressionBuilder })
@@ -469,7 +469,7 @@ export function registerPTypes(typeRegistry: TypeRegistry) {
   // This ensures the specific type is selected during type resolution
   // For example, StaticBytesExpressionBuilder should be selected over general StaticArrayExpressionBuilder for StaticBytesType
   typeRegistry.register({ ptype: DynamicBytesConstructor, singletonEb: DynamicBytesClassBuilder })
-  typeRegistry.register({ ptype: DynamicBytesType, instanceEb: DynamicBytesExpressionBuilder })
+  typeRegistry.register({ ptype: dynamicBytesType, instanceEb: DynamicBytesExpressionBuilder })
   typeRegistry.registerGeneric({
     generic: StaticBytesGeneric,
     ptype: StaticBytesType,

--- a/src/awst_build/type-resolver.ts
+++ b/src/awst_build/type-resolver.ts
@@ -516,7 +516,7 @@ export class TypeResolver {
     })
   }
 
-  getTypeName(type: ts.Type): SymbolName | undefined {
+  private getTypeName(type: ts.Type): SymbolName | undefined {
     const typeName = type.symbol ? this.getSymbolFullName(type.symbol) : undefined
     const aliasName = type.aliasSymbol ? this.getSymbolFullName(type.aliasSymbol) : undefined
 

--- a/src/awst_build/type-resolver.ts
+++ b/src/awst_build/type-resolver.ts
@@ -88,7 +88,7 @@ export class TypeResolver {
   resolve(node: ts.Node, sourceLocation: SourceLocation): PType {
     const symbol = this.getUnaliasedSymbolForNode(node)
     if (symbol !== undefined && symbol.declarations?.length) {
-      const symbolName = symbol && this.getSymbolFullName(symbol, sourceLocation)
+      const symbolName = this.getSymbolFullName(symbol)
       invariant(symbolName, 'Symbol should have name as we pre-checked it has a declaration', sourceLocation)
       if (symbolName.name === '*') {
         return new NamespacePType(symbolName)
@@ -118,7 +118,7 @@ export class TypeResolver {
     if (ts.isConstructorDeclaration(node)) {
       const signature = this.checker.getSignatureFromDeclaration(node)
       invariant(signature, 'Constructor node must have call signature', sourceLocation)
-      const parentType = this.getTypeName(this.checker.getTypeAtLocation(node.parent), sourceLocation)
+      const parentType = this.getTypeName(this.checker.getTypeAtLocation(node.parent))
       invariant(parentType, 'Parent type must have name', sourceLocation)
       return this.reflectFunctionType(
         new SymbolName({
@@ -139,7 +139,7 @@ export class TypeResolver {
 
   @CacheResolvedType
   resolveType(tsType: ts.Type, sourceLocation: SourceLocation): PType {
-    const typeName = this.getTypeName(tsType, sourceLocation)
+    const typeName = this.getTypeName(tsType)
 
     if (isUnionType(tsType)) {
       const ut = UnionPType.fromTypes(tsType.types.map((t) => this.resolveType(t, sourceLocation)))
@@ -354,7 +354,7 @@ export class TypeResolver {
   }
 
   private reflectObjectType(tsType: ts.Type, sourceLocation: SourceLocation): ImmutableObjectPType | MutableObjectPType {
-    const typeAlias = tsType.aliasSymbol ? this.getSymbolFullName(tsType.aliasSymbol, sourceLocation) : undefined
+    const typeAlias = tsType.aliasSymbol ? this.getSymbolFullName(tsType.aliasSymbol) : undefined
     const properties: PTypeField[] = []
 
     let expectReadonly: boolean | undefined = undefined
@@ -420,7 +420,7 @@ export class TypeResolver {
     const declaredInNode = sig.declaration?.parent
     if (declaredInNode && ts.isClassDeclaration(declaredInNode)) {
       const declaredInType = this.checker.getTypeAtLocation(declaredInNode)
-      declaredIn = this.getTypeName(declaredInType, sourceLocation)
+      declaredIn = this.getTypeName(declaredInType)
     }
 
     const returnType = this.resolveType(sig.getReturnType(), sourceLocation)
@@ -516,9 +516,9 @@ export class TypeResolver {
     })
   }
 
-  getTypeName(type: ts.Type, sourceLocation: SourceLocation): SymbolName | undefined {
-    const typeName = type.symbol ? this.getSymbolFullName(type.symbol, sourceLocation) : undefined
-    const aliasName = type.aliasSymbol ? this.getSymbolFullName(type.aliasSymbol, sourceLocation) : undefined
+  getTypeName(type: ts.Type): SymbolName | undefined {
+    const typeName = type.symbol ? this.getSymbolFullName(type.symbol) : undefined
+    const aliasName = type.aliasSymbol ? this.getSymbolFullName(type.aliasSymbol) : undefined
 
     // If the alias was defined in algo-ts, polytype, or typescript, respect the alias
     if (
@@ -535,7 +535,7 @@ export class TypeResolver {
         if (parentDeclaration && ts.isTypeAliasDeclaration(parentDeclaration)) {
           const name = this.getUnaliasedSymbolForNode(parentDeclaration.name)
           if (name) {
-            return this.getSymbolFullName(name, sourceLocation)
+            return this.getSymbolFullName(name)
           }
         }
       }
@@ -554,7 +554,7 @@ export class TypeResolver {
     return dec?.localSymbol?.name
   }
 
-  private getSymbolFullName(symbol: ts.Symbol, sourceLocation: SourceLocation): SymbolName | undefined {
+  private getSymbolFullName(symbol: ts.Symbol): SymbolName | undefined {
     const symbolName = symbol.name === 'default' ? (this.tryGetLocalSymbolName(symbol) ?? symbol.name) : symbol.name
 
     const declaration = symbol?.declarations?.[0]

--- a/src/awst_build/type-resolver.ts
+++ b/src/awst_build/type-resolver.ts
@@ -65,13 +65,12 @@ export class TypeResolver {
 
   private getUnaliasedSymbolForNode(node: ts.Node) {
     const symbol = this.checker.getSymbolAtLocation(node)
-    if (symbol) {
-      if (hasFlags(symbol.flags, ts.SymbolFlags.Alias)) {
-        return this.checker.getAliasedSymbol(symbol)
-      }
-      return symbol
+    if (!symbol) return undefined
+
+    if (hasFlags(symbol.flags, ts.SymbolFlags.Alias)) {
+      return this.checker.getAliasedSymbol(symbol)
     }
-    return undefined
+    return symbol
   }
 
   resolveTypeParameters(node: ts.CallExpression | ts.NewExpression | ts.TaggedTemplateExpression, sourceLocation: SourceLocation) {

--- a/src/awst_build/type-resolver.ts
+++ b/src/awst_build/type-resolver.ts
@@ -372,7 +372,7 @@ export class TypeResolver {
       if (expectReadonly !== readonly) {
         const correction = expectReadonly
           ? 'Add a readonly modifier to this property, or remove it from all others'
-          : 'Remove the readonly modifier from this property, or add it all others'
+          : 'Remove the readonly modifier from this property, or add it to all others'
         logger.error(propLocation, `All properties of a type must share the same readonly annotation. ${correction}`)
       }
       const ptype = this.resolveType(type, propLocation)
@@ -505,7 +505,7 @@ export class TypeResolver {
         // Ignore for now
       } else {
         throw new CodeError(
-          `Unexpected type: ${t}. Polytype can only be used to support multiple inheritance in contracts for now. All base types must extend the Contract or BaseContract class.}`,
+          `Unexpected type: ${t}. Polytype can only be used to support multiple inheritance in contracts for now. All base types must extend the Contract or BaseContract class.`,
         )
       }
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,8 +3,12 @@ const algoTsPackage = '@algorandfoundation/algorand-typescript'
 export const Constants = {
   algoTsPackage,
   moduleNames: {
+    tslib: 'lib.d.ts',
     typescript: {
+      decorators: 'typescript/lib/lib.decorators.d.ts',
       es5: 'typescript/lib/lib.es5.d.ts',
+      generator: 'typescript/lib/lib.es2015.generator.d.ts',
+      iterable: 'typescript/lib/lib.es2015.iterable.d.ts',
     },
     polytype: 'polytype/lib/polytype-module.d.ts',
     algoTs: {
@@ -33,6 +37,7 @@ export const Constants = {
       util: `${algoTsPackage}/util.d.ts`,
       mutableObject: `${algoTsPackage}/mutable-object.d.ts`,
     },
+    puyaTs: 'puya-ts',
   },
 
   symbolNames: {


### PR DESCRIPTION
- refactor: small control-flow and shorthand cleanups         
- refactor: tighten field/method visibility and signature types         
- refactor: rename internal symbols for consistency         
- chore: clean up generic-ptype error messages and typos         
- refactor: route module-name and decorator literals through Constants         
- refactor: drop dead and unnecessary code         
- refactor: deduplicate repeated logic into shared helpers and base types         
 - fix: include sourceLocation when reporting error sites
