### PR TITLE
build: add if condition to release job to prevent falling back to default `success()` check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
   release:
     name: Release
     needs: ci
+    if: needs.ci.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Generate bot token


### PR DESCRIPTION
- any job without an explicit `if` condition fallbacks to default `if: success()` 
- default `success()` check needs ALL of the ancestors to have run successfully 
- if any ancestor is skipped (i.e. not run successfully), it will fail and the job will be skipped