### PR TITLE
fix: add one of the status check functions to avoid default `success()`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
   release:
     name: Release
     needs: ci
-    if: needs.ci.result == 'success'
+    if: ${{ !cancelled() && needs.ci.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate bot token


### PR DESCRIPTION
- `success()` requires ALL of the ancestors to have run successfully, not skipped, not cancelled, not failed

- https://github.com/actions/runner/issues/491#issuecomment-660122693 
- https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions