### PR TITLE
chore: rename ptypes for consistency

### DIFF
--- a/src/awst_build/eb/arc4/arrays.ts
+++ b/src/awst_build/eb/arc4/arrays.ts
@@ -17,8 +17,8 @@ import {
   arc4AddressAlias,
   DynamicArrayGeneric,
   DynamicArrayType,
-  DynamicBytesConstructor,
-  DynamicBytesType,
+  DynamicBytesClass,
+  dynamicBytesType,
   StaticArrayGeneric,
   StaticArrayType,
   StaticBytesGeneric,
@@ -226,7 +226,7 @@ export class StaticBytesClassBuilder extends ClassBuilder {
   }
 }
 export class DynamicBytesClassBuilder extends ClassBuilder {
-  readonly ptype = DynamicBytesConstructor
+  readonly ptype = DynamicBytesClass
 
   newCall(args: ReadonlyArray<NodeBuilder>, typeArgs: ReadonlyArray<PType>, sourceLocation: SourceLocation): InstanceBuilder {
     const {
@@ -239,7 +239,7 @@ export class DynamicBytesClassBuilder extends ClassBuilder {
       genericTypeArgs: 0,
       argSpec: (a) => [a.optional(bytesPType, stringPType)],
     })
-    const resultPType = DynamicBytesType
+    const resultPType = dynamicBytesType
 
     if (!initialValue) {
       return instanceEb(

--- a/src/awst_build/eb/arc4/c2c.ts
+++ b/src/awst_build/eb/arc4/c2c.ts
@@ -20,7 +20,7 @@ import { arc4ConfigFromType, buildArc4MethodConstant } from '../../arc4-util'
 import { AwstBuildContext } from '../../context/awst-build-context'
 import type { PType } from '../../ptypes'
 import {
-  applicationItxnType,
+  applicationCallItxnType,
   bytesPType,
   compiledContractType,
   FunctionPType,
@@ -161,7 +161,7 @@ class ContractProxyBareCreateFunctionBuilder extends FunctionBuilder {
       applicationProxy: this.proxy,
     })
 
-    return instanceEb(itxnResult, applicationItxnType)
+    return instanceEb(itxnResult, applicationCallItxnType)
   }
 }
 class ContractProxyCallBuilder extends NodeBuilder {

--- a/src/awst_build/eb/arc4/tuple.ts
+++ b/src/awst_build/eb/arc4/tuple.ts
@@ -8,7 +8,7 @@ import { logger } from '../../../logger'
 import { codeInvariant, invariant } from '../../../util'
 import type { PType } from '../../ptypes'
 import { numberPType, uint64PType } from '../../ptypes'
-import { ARC4EncodedType, Arc4TupleGeneric, ARC4TupleType } from '../../ptypes/arc4-types'
+import { ARC4EncodedType, ARC4TupleGeneric, ARC4TupleType } from '../../ptypes/arc4-types'
 import { instanceEb } from '../../type-registry'
 import type { InstanceBuilder, NodeBuilder } from '../index'
 import { ClassBuilder, FunctionBuilder } from '../index'
@@ -17,7 +17,7 @@ import { parseFunctionArgs } from '../util/arg-parsing'
 import { Arc4EncodedBaseExpressionBuilder } from './base'
 
 export class Arc4TupleClassBuilder extends ClassBuilder {
-  readonly ptype = Arc4TupleGeneric
+  readonly ptype = ARC4TupleGeneric
 
   newCall(args: ReadonlyArray<NodeBuilder>, typeArgs: ReadonlyArray<PType>, sourceLocation: SourceLocation): InstanceBuilder {
     const {
@@ -31,7 +31,7 @@ export class Arc4TupleClassBuilder extends ClassBuilder {
       callLocation: sourceLocation,
       argSpec: (a) => args.map(() => a.required()),
     })
-    const ptype = Arc4TupleGeneric.parameterise([tupleType])
+    const ptype = ARC4TupleGeneric.parameterise([tupleType])
 
     if (args.length === 0) {
       return new Arc4TupleExpressionBuilder(

--- a/src/awst_build/eb/clone-function-builder.ts
+++ b/src/awst_build/eb/clone-function-builder.ts
@@ -2,14 +2,14 @@ import type ts from 'typescript'
 import { nodeFactory } from '../../awst/node-factory'
 import type { SourceLocation } from '../../awst/source-location'
 import type { PType } from '../ptypes'
-import { cloneFunctionPType } from '../ptypes'
+import { cloneFunction } from '../ptypes'
 import { instanceEb } from '../type-registry'
 import type { InstanceBuilder } from './index'
 import { FunctionBuilder, type NodeBuilder } from './index'
 import { parseFunctionArgs } from './util/arg-parsing'
 
 export class CloneFunctionBuilder extends FunctionBuilder {
-  readonly ptype = cloneFunctionPType
+  readonly ptype = cloneFunction
 
   call(args: ReadonlyArray<NodeBuilder>, typeArgs: ReadonlyArray<PType>, sourceLocation: SourceLocation<ts.CallExpression>): NodeBuilder {
     const {

--- a/src/awst_build/eb/compiled/compile-function.ts
+++ b/src/awst_build/eb/compiled/compile-function.ts
@@ -9,7 +9,7 @@ import type { PType } from '../../ptypes'
 import {
   compiledContractType,
   compiledLogicSigType,
-  compileFunctionType,
+  compileFunction,
   ContractClassPType,
   isObjectType,
   LogicSigPType,
@@ -22,7 +22,7 @@ import { requireBuilderOfType, requireInstanceBuilder, requireStringConstant } f
 import { parseFunctionArgs } from '../util/arg-parsing'
 
 export class CompileFunctionBuilder extends FunctionBuilder {
-  readonly ptype = compileFunctionType
+  readonly ptype = compileFunction
 
   call(args: ReadonlyArray<NodeBuilder>, typeArgs: ReadonlyArray<PType>, sourceLocation: SourceLocation<ts.CallExpression>): NodeBuilder {
     const {

--- a/src/awst_build/eb/transactions/util.ts
+++ b/src/awst_build/eb/transactions/util.ts
@@ -4,7 +4,7 @@ import {
   anyGtxnType,
   applicationCallGtxnType,
   applicationCallItxnParamsType,
-  applicationItxnType,
+  applicationCallItxnType,
   assetConfigGtxnType,
   assetConfigItxnParamsType,
   assetConfigItxnType,
@@ -35,7 +35,7 @@ export function getInnerTransactionType(kind: TransactionKind): InnerTransaction
     case TransactionKind.afrz:
       return assetFreezeItxnType
     case TransactionKind.appl:
-      return applicationItxnType
+      return applicationCallItxnType
   }
 }
 export function getItxnParamsType(kind: TransactionKind): ItxnParamsPType {

--- a/src/awst_build/eb/util/array/concat.ts
+++ b/src/awst_build/eb/util/array/concat.ts
@@ -7,7 +7,7 @@ import { CodeError } from '../../../../errors'
 import { bigIntToUint8Array, codeInvariant } from '../../../../util'
 import type { PType } from '../../../ptypes'
 import { ArrayLiteralPType, ArrayPType, FixedArrayPType, MutableTuplePType, ReadonlyArrayPType, ReadonlyTuplePType } from '../../../ptypes'
-import { ARC4ArrayType, DynamicArrayType, DynamicBytesType, StaticArrayType, StaticBytesType } from '../../../ptypes/arc4-types'
+import { ARC4ArrayType, DynamicArrayType, dynamicBytesType, StaticArrayType, StaticBytesType } from '../../../ptypes/arc4-types'
 import { containsMutableType } from '../../../ptypes/visitors/contains-mutable-visitor'
 import { instanceEb } from '../../../type-registry'
 import type { InstanceBuilder } from '../../index'
@@ -24,7 +24,7 @@ export function concatArrays(left: InstanceBuilder, right: InstanceBuilder, sour
       TODO: This is only required because puya doesn't support staticarray + other => dynamic array
       To work around this, we convert arc4 static bytes and static array to dynamic bytes and dynamic array
      */
-    const dynamicType = left.ptype instanceof StaticBytesType ? DynamicBytesType : new DynamicArrayType({ ...left.ptype })
+    const dynamicType = left.ptype instanceof StaticBytesType ? dynamicBytesType : new DynamicArrayType({ ...left.ptype })
     return concatArrays(toArc4Dynamic(left.ptype.arraySize, left.resolve(), dynamicType), right, sourceLocation)
   } else if (left.ptype instanceof FixedArrayPType || left.ptype instanceof ReadonlyArrayPType) {
     /*
@@ -59,8 +59,8 @@ function getArrayConcatType(left: PType, right: PType, sourceLocation: SourceLoc
   if (left instanceof ARC4ArrayType) {
     if (right instanceof ARC4ArrayType) {
       sameElementType(left.elementType, right.elementType, sourceLocation)
-      if (left.equals(DynamicBytesType) || left instanceof StaticBytesType) {
-        return DynamicBytesType
+      if (left.equals(dynamicBytesType) || left instanceof StaticBytesType) {
+        return dynamicBytesType
       }
       return new DynamicArrayType({
         elementType: left.elementType,

--- a/src/awst_build/eb/validate-encoding-function-builder.ts
+++ b/src/awst_build/eb/validate-encoding-function-builder.ts
@@ -2,14 +2,14 @@ import { nodeFactory } from '../../awst/node-factory'
 import type { SourceLocation } from '../../awst/source-location'
 import { wtypes } from '../../awst/wtypes'
 import { codeInvariant } from '../../util'
-import { accountPType, BytesPType, validateEncodingFunctionPType, voidPType, type PType } from '../ptypes'
+import { accountPType, BytesPType, validateEncodingFunction, voidPType, type PType } from '../ptypes'
 import { arc4AddressAlias, StaticBytesType } from '../ptypes/arc4-types'
 import { instanceEb } from '../type-registry'
 import { FunctionBuilder, type NodeBuilder } from './index'
 import { parseFunctionArgs } from './util/arg-parsing'
 
 export class ValidateEncodingFunctionBuilder extends FunctionBuilder {
-  readonly ptype = validateEncodingFunctionPType
+  readonly ptype = validateEncodingFunction
 
   call(args: ReadonlyArray<NodeBuilder>, typeArgs: ReadonlyArray<PType>, sourceLocation: SourceLocation): NodeBuilder {
     const {

--- a/src/awst_build/ptypes/arc4-types.ts
+++ b/src/awst_build/ptypes/arc4-types.ts
@@ -6,7 +6,7 @@ import type { PTypeField } from './base'
 import { GenericPType, PType } from './base'
 import {
   accountPType,
-  applicationItxnType,
+  applicationCallItxnType,
   ArrayPType,
   biguintPType,
   boolPType,
@@ -227,7 +227,7 @@ export const arc4StructBaseType = new ARC4StructType({
   frozen: false,
 })
 
-export const Arc4TupleGeneric = new GenericPType({
+export const ARC4TupleGeneric = new GenericPType({
   name: 'Tuple',
   module: Constants.moduleNames.algoTs.arc4.encodedTypes,
   parameterise([tupleType, ...rest]: readonly PType[]) {
@@ -546,11 +546,11 @@ export class StaticBytesType extends StaticArrayType {
     })
   }
 }
-export const DynamicBytesConstructor = new LibClassType({
+export const DynamicBytesClass = new LibClassType({
   name: 'DynamicBytes',
   module: Constants.moduleNames.algoTs.arc4.encodedTypes,
 })
-export const DynamicBytesType = new DynamicArrayType({
+export const dynamicBytesType = new DynamicArrayType({
   name: 'DynamicBytes',
   immutable: true,
   elementType: arc4ByteAlias,
@@ -640,11 +640,11 @@ export class TypedApplicationCallResponseType extends ImmutableObjectPType {
   constructor({ returnValue }: { returnValue: PType }) {
     super({
       properties: returnValue.equals(voidPType)
-        ? [{ name: 'itxn', ptype: applicationItxnType, description: null }]
+        ? [{ name: 'itxn', ptype: applicationCallItxnType, description: null }]
         : [
             {
               name: 'itxn',
-              ptype: applicationItxnType,
+              ptype: applicationCallItxnType,
               description: null,
             },
             {

--- a/src/awst_build/ptypes/index.ts
+++ b/src/awst_build/ptypes/index.ts
@@ -771,7 +771,7 @@ abstract class TupleBasePType extends PType {
 export class MutableTuplePType extends TupleBasePType {
   readonly [PType.IdSymbol] = 'MutableTuplePType'
   constructor(props: { items: PType[] }) {
-    super({ ...props })
+    super(props)
   }
 
   get wtype(): wtypes.ARC4Tuple {
@@ -891,7 +891,7 @@ export class FixedArrayPType extends PType {
   readonly module: string = Constants.moduleNames.algoTs.arrays
   readonly arraySize: bigint
   get fullName() {
-    return `${this.module}::FixedArray<${this.elementType.fullName}>`
+    return `${this.module}::FixedArray<${this.elementType.fullName}, ${this.arraySize}>`
   }
   constructor(props: { elementType: PType; arraySize: bigint }) {
     super()
@@ -1327,7 +1327,7 @@ export const applicationPType = new ABICompatibleInstanceType({
   module: Constants.moduleNames.algoTs.reference,
   abiTypeSignature: 'application',
 })
-export const ApplicationFunctionType = new LibFunctionType({
+export const ApplicationFunction = new LibFunctionType({
   name: 'Application',
   module: Constants.moduleNames.algoTs.reference,
 })
@@ -1481,7 +1481,7 @@ export const applicationCallGtxnType = new GroupTransactionPType({
   name: 'ApplicationCallTxn',
   kind: TransactionKind.appl,
 })
-export const ApplicationTxnFunction = new TransactionFunctionType({
+export const ApplicationCallTxnFunction = new TransactionFunctionType({
   name: 'ApplicationCallTxn',
   module: Constants.moduleNames.algoTs.gtxn,
   kind: TransactionKind.appl,
@@ -1682,32 +1682,32 @@ export class GeneratorType extends UnsupportedType {
   }
 }
 
-export const paymentItxnFn = new TransactionFunctionType({
+export const paymentItxnFunction = new TransactionFunctionType({
   name: 'payment',
   module: Constants.moduleNames.algoTs.itxn,
   kind: TransactionKind.pay,
 })
-export const keyRegistrationItxnFn = new TransactionFunctionType({
+export const keyRegistrationItxnFunction = new TransactionFunctionType({
   name: 'keyRegistration',
   module: Constants.moduleNames.algoTs.itxn,
   kind: TransactionKind.keyreg,
 })
-export const assetConfigItxnFn = new TransactionFunctionType({
+export const assetConfigItxnFunction = new TransactionFunctionType({
   name: 'assetConfig',
   module: Constants.moduleNames.algoTs.itxn,
   kind: TransactionKind.acfg,
 })
-export const assetTransferItxnFn = new TransactionFunctionType({
+export const assetTransferItxnFunction = new TransactionFunctionType({
   name: 'assetTransfer',
   module: Constants.moduleNames.algoTs.itxn,
   kind: TransactionKind.axfer,
 })
-export const assetFreezeItxnFn = new TransactionFunctionType({
+export const assetFreezeItxnFunction = new TransactionFunctionType({
   name: 'assetFreeze',
   module: Constants.moduleNames.algoTs.itxn,
   kind: TransactionKind.afrz,
 })
-export const applicationCallItxnFn = new TransactionFunctionType({
+export const applicationCallItxnFunction = new TransactionFunctionType({
   name: 'applicationCall',
   module: Constants.moduleNames.algoTs.itxn,
   kind: TransactionKind.appl,
@@ -1801,7 +1801,7 @@ export const applicationCallItxnParamsType = new ItxnParamsPType({
   name: 'ApplicationCallItxnParams',
   kind: TransactionKind.appl,
 })
-export const applicationItxnType = new InnerTransactionPType({
+export const applicationCallItxnType = new InnerTransactionPType({
   name: 'ApplicationCallInnerTxn',
   kind: TransactionKind.appl,
 })
@@ -1836,7 +1836,7 @@ export const TemplateVarFunction = new LibFunctionType({
   module: Constants.moduleNames.algoTs.templateVar,
 })
 
-export const compileFunctionType = new LibFunctionType({
+export const compileFunction = new LibFunctionType({
   name: 'compile',
   module: Constants.moduleNames.algoTs.compiled,
 })
@@ -1943,12 +1943,12 @@ export const itxnComposePType = new LibObjType({
   name: 'itxnCompose',
 })
 
-export const cloneFunctionPType = new LibFunctionType({
+export const cloneFunction = new LibFunctionType({
   name: 'clone',
   module: Constants.moduleNames.algoTs.util,
 })
 
-export const validateEncodingFunctionPType = new LibFunctionType({
+export const validateEncodingFunction = new LibFunctionType({
   name: 'validateEncoding',
   module: Constants.moduleNames.algoTs.util,
 })

--- a/src/awst_build/ptypes/register.ts
+++ b/src/awst_build/ptypes/register.ts
@@ -103,7 +103,7 @@ import {
   arc4StringType,
   ARC4StructClass,
   ARC4StructType,
-  Arc4TupleGeneric,
+  ARC4TupleGeneric,
   ARC4TupleType,
   ByteClass,
   compileArc4Function,
@@ -113,8 +113,8 @@ import {
   decodeArc4Function,
   DynamicArrayGeneric,
   DynamicArrayType,
-  DynamicBytesConstructor,
-  DynamicBytesType,
+  DynamicBytesClass,
+  dynamicBytesType,
   encodeArc4Function,
   methodSelectorFunction,
   sizeOfFunction,
@@ -138,12 +138,12 @@ import {
   accountPType,
   anyGtxnType,
   applicationCallGtxnType,
-  applicationCallItxnFn,
+  applicationCallItxnFunction,
   applicationCallItxnParamsType,
-  ApplicationFunctionType,
-  applicationItxnType,
+  applicationCallItxnType,
+  ApplicationCallTxnFunction,
+  ApplicationFunction,
   applicationPType,
-  ApplicationTxnFunction,
   arc28EmitFunction,
   arc4AbiMethodDecorator,
   arc4BareMethodDecorator,
@@ -153,19 +153,19 @@ import {
   assertFunction,
   assertMatchFunction,
   assetConfigGtxnType,
-  assetConfigItxnFn,
+  assetConfigItxnFunction,
   assetConfigItxnParamsType,
   assetConfigItxnType,
   AssetConfigTxnFunction,
   assetFreezeGtxnType,
-  assetFreezeItxnFn,
+  assetFreezeItxnFunction,
   assetFreezeItxnParamsType,
   assetFreezeItxnType,
   AssetFreezeTxnFunction,
   AssetFunction,
   assetPType,
   assetTransferGtxnType,
-  assetTransferItxnFn,
+  assetTransferItxnFunction,
   assetTransferItxnParamsType,
   assetTransferItxnType,
   AssetTransferTxnFunction,
@@ -183,8 +183,8 @@ import {
   BytesPType,
   bzeroFunction,
   ClassMethodDecoratorContext,
-  cloneFunctionPType,
-  compileFunctionType,
+  cloneFunction,
+  compileFunction,
   ContractClassPType,
   contractOptionsDecorator,
   ensureBudgetFunction,
@@ -208,7 +208,7 @@ import {
   IterableIteratorType,
   itxnComposePType,
   keyRegistrationGtxnType,
-  keyRegistrationItxnFn,
+  keyRegistrationItxnFunction,
   keyRegistrationItxnParamsType,
   keyRegistrationItxnType,
   KeyRegistrationTxnFunction,
@@ -230,7 +230,7 @@ import {
   onCompleteActionType,
   opUpFeeSourceType,
   paymentGtxnType,
-  paymentItxnFn,
+  paymentItxnFunction,
   paymentItxnParamsType,
   paymentItxnType,
   PaymentTxnFunction,
@@ -256,7 +256,7 @@ import {
   Uint64Function,
   uint64PType,
   urangeFunction,
-  validateEncodingFunctionPType,
+  validateEncodingFunction,
   voidPType,
 } from './index'
 import { ALL_OP_ENUMS } from './op-ptypes'
@@ -332,10 +332,10 @@ export function registerPTypes(typeRegistry: TypeRegistry) {
   typeRegistry.register({ ptype: ensureBudgetFunction, singletonEb: EnsureBudgetFunctionBuilder })
   typeRegistry.register({ ptype: urangeFunction, singletonEb: UrangeFunctionBuilder })
   typeRegistry.register({ ptype: TemplateVarFunction, singletonEb: TemplateVarFunctionBuilder })
-  typeRegistry.register({ ptype: compileFunctionType, singletonEb: CompileFunctionBuilder })
+  typeRegistry.register({ ptype: compileFunction, singletonEb: CompileFunctionBuilder })
   typeRegistry.register({ ptype: arc28EmitFunction, singletonEb: Arc28EmitFunctionBuilder })
-  typeRegistry.register({ ptype: cloneFunctionPType, singletonEb: CloneFunctionBuilder })
-  typeRegistry.register({ ptype: validateEncodingFunctionPType, singletonEb: ValidateEncodingFunctionBuilder })
+  typeRegistry.register({ ptype: cloneFunction, singletonEb: CloneFunctionBuilder })
+  typeRegistry.register({ ptype: validateEncodingFunction, singletonEb: ValidateEncodingFunctionBuilder })
   typeRegistry.register({ ptype: ContractClassPType, singletonEb: ContractClassBuilder })
   typeRegistry.register({ ptype: contractOptionsDecorator, singletonEb: ContractOptionsDecoratorBuilder })
   typeRegistry.register({ ptype: LogicSigPType, singletonEb: LogicSigClassBuilder })
@@ -433,7 +433,7 @@ export function registerPTypes(typeRegistry: TypeRegistry) {
   })
 
   // Reference types
-  typeRegistry.register({ ptype: ApplicationFunctionType, singletonEb: ApplicationFunctionBuilder })
+  typeRegistry.register({ ptype: ApplicationFunction, singletonEb: ApplicationFunctionBuilder })
   typeRegistry.register({ ptype: applicationPType, instanceEb: ApplicationExpressionBuilder })
   typeRegistry.register({ ptype: AccountFunction, singletonEb: AccountFunctionBuilder })
   typeRegistry.register({ ptype: accountPType, instanceEb: AccountExpressionBuilder })
@@ -468,8 +468,8 @@ export function registerPTypes(typeRegistry: TypeRegistry) {
   // More specific types need to be registered before their base types
   // This ensures the specific type is selected during type resolution
   // For example, StaticBytesExpressionBuilder should be selected over general StaticArrayExpressionBuilder for StaticBytesType
-  typeRegistry.register({ ptype: DynamicBytesConstructor, singletonEb: DynamicBytesClassBuilder })
-  typeRegistry.register({ ptype: DynamicBytesType, instanceEb: DynamicBytesExpressionBuilder })
+  typeRegistry.register({ ptype: DynamicBytesClass, singletonEb: DynamicBytesClassBuilder })
+  typeRegistry.register({ ptype: dynamicBytesType, instanceEb: DynamicBytesExpressionBuilder })
   typeRegistry.registerGeneric({
     generic: StaticBytesGeneric,
     ptype: StaticBytesType,
@@ -496,7 +496,7 @@ export function registerPTypes(typeRegistry: TypeRegistry) {
   typeRegistry.register({ ptype: arc4StringType, instanceEb: StrExpressionBuilder })
   typeRegistry.register({ ptype: ARC4StrClass, singletonEb: StrClassBuilder })
   typeRegistry.registerGeneric({
-    generic: Arc4TupleGeneric,
+    generic: ARC4TupleGeneric,
     ptype: ARC4TupleType,
     instanceEb: Arc4TupleExpressionBuilder,
     singletonEb: Arc4TupleClassBuilder,
@@ -526,17 +526,17 @@ export function registerPTypes(typeRegistry: TypeRegistry) {
   typeRegistry.register({ ptype: assetFreezeGtxnType, instanceEb: GroupTransactionExpressionBuilder })
   typeRegistry.register({ ptype: AssetFreezeTxnFunction, singletonEb: GroupTransactionFunctionBuilder })
   typeRegistry.register({ ptype: applicationCallGtxnType, instanceEb: GroupTransactionExpressionBuilder })
-  typeRegistry.register({ ptype: ApplicationTxnFunction, singletonEb: GroupTransactionFunctionBuilder })
+  typeRegistry.register({ ptype: ApplicationCallTxnFunction, singletonEb: GroupTransactionFunctionBuilder })
   typeRegistry.register({ ptype: anyGtxnType, instanceEb: GroupTransactionExpressionBuilder })
   typeRegistry.register({ ptype: TransactionFunction, singletonEb: GroupTransactionFunctionBuilder })
 
   // ITXN Types
-  typeRegistry.register({ ptype: paymentItxnFn, singletonEb: ItxnParamsFactoryFunctionBuilder })
-  typeRegistry.register({ ptype: keyRegistrationItxnFn, singletonEb: ItxnParamsFactoryFunctionBuilder })
-  typeRegistry.register({ ptype: assetConfigItxnFn, singletonEb: ItxnParamsFactoryFunctionBuilder })
-  typeRegistry.register({ ptype: assetTransferItxnFn, singletonEb: ItxnParamsFactoryFunctionBuilder })
-  typeRegistry.register({ ptype: assetFreezeItxnFn, singletonEb: ItxnParamsFactoryFunctionBuilder })
-  typeRegistry.register({ ptype: applicationCallItxnFn, singletonEb: ItxnParamsFactoryFunctionBuilder })
+  typeRegistry.register({ ptype: paymentItxnFunction, singletonEb: ItxnParamsFactoryFunctionBuilder })
+  typeRegistry.register({ ptype: keyRegistrationItxnFunction, singletonEb: ItxnParamsFactoryFunctionBuilder })
+  typeRegistry.register({ ptype: assetConfigItxnFunction, singletonEb: ItxnParamsFactoryFunctionBuilder })
+  typeRegistry.register({ ptype: assetTransferItxnFunction, singletonEb: ItxnParamsFactoryFunctionBuilder })
+  typeRegistry.register({ ptype: assetFreezeItxnFunction, singletonEb: ItxnParamsFactoryFunctionBuilder })
+  typeRegistry.register({ ptype: applicationCallItxnFunction, singletonEb: ItxnParamsFactoryFunctionBuilder })
   typeRegistry.register({ ptype: submitGroupItxnFunction, singletonEb: SubmitItxnGroupFunctionBuilder })
 
   typeRegistry.register({ ptype: paymentItxnType, instanceEb: InnerTransactionExpressionBuilder })
@@ -544,7 +544,7 @@ export function registerPTypes(typeRegistry: TypeRegistry) {
   typeRegistry.register({ ptype: assetConfigItxnType, instanceEb: InnerTransactionExpressionBuilder })
   typeRegistry.register({ ptype: assetTransferItxnType, instanceEb: InnerTransactionExpressionBuilder })
   typeRegistry.register({ ptype: assetFreezeItxnType, instanceEb: InnerTransactionExpressionBuilder })
-  typeRegistry.register({ ptype: applicationItxnType, instanceEb: InnerTransactionExpressionBuilder })
+  typeRegistry.register({ ptype: applicationCallItxnType, instanceEb: InnerTransactionExpressionBuilder })
 
   typeRegistry.register({ ptype: paymentItxnParamsType, instanceEb: ItxnParamsExpressionBuilder })
   typeRegistry.register({ ptype: keyRegistrationItxnParamsType, instanceEb: ItxnParamsExpressionBuilder })


### PR DESCRIPTION
- use consistent `Function` suffix
  - ApplicationFunctionType → ApplicationFunction
  - ApplicationTxnFunction → ApplicationCallTxnFunction
  - paymentItxnFn → paymentItxnFunction
  - keyRegistrationItxnFn → keyRegistrationItxnFunction
  - assetConfigItxnFn → assetConfigItxnFunction
  - assetTransferItxnFn → assetTransferItxnFunction
  - assetFreezeItxnFn → assetFreezeItxnFunction
  - applicationCallItxnFn → applicationCallItxnFunction
  - compileFunctionType → compileFunction
  - cloneFunctionPType → cloneFunction
  - validateEncodingFunctionPType → validateEncodingFunction

- restore missing `Call` component
  - applicationItxnType → applicationCallItxnType

- use consistent arc4 casing
  - Arc4TupleGeneric → ARC4TupleGeneric

- use consistent `Class` suffix
  - DynamicBytesConstructor → DynamicBytesClass

- use camelCase for type instance
  - DynamicBytesType → dynamicBytesType

- add size to `fullName` property of `FixedArrayPType`