### PR TITLE
refactor: awst serialisation to reduce code repetition and make intent clearer

### DIFF
--- a/src/awst/json-serialize-awst.ts
+++ b/src/awst/json-serialize-awst.ts
@@ -1,7 +1,7 @@
 import { snakeCase } from 'change-case'
 import { InternalError } from '../errors'
 import { AbsolutePath } from '../util/absolute-path'
-import { buildBase85Encoder } from '../util/base-85'
+import { uint8ArrayToBase85 } from '../util/base-85'
 import { ContractReference, LogicSigReference } from './models'
 import { IntrinsicCall, SingleEvaluation } from './nodes'
 import { generateExcludedPropsObj } from './nodes-meta'
@@ -27,19 +27,10 @@ export class SnakeCaseSerializer<T> {
   public serialize(obj: T): string {
     return JSON.stringify(obj, (k, v) => this.serializerFunction(k, v), this.spaces)
   }
-  private b85 = buildBase85Encoder()
 
   protected serializerFunction(key: string, value: unknown): unknown {
-    if (typeof value === 'bigint') {
-      return serializeBigInt(value)
-    }
-    if (value instanceof Uint8Array) {
-      return this.b85.encode(value)
-    }
     if (value instanceof Object && value.constructor.name !== 'Date' && value.constructor.name !== 'Object') {
-      return {
-        ...Object.fromEntries(Object.entries(value).map(([key, value]) => [snakeCase(key), value])),
-      }
+      return Object.fromEntries(Object.entries(value).map(([key, value]) => [snakeCase(key), value]))
     }
     return value
   }
@@ -57,6 +48,12 @@ export class AwstSerializer<T> extends SnakeCaseSerializer<T> {
   #singleEvals = new SymbolToNumber()
 
   protected serializerFunction(key: string, value: unknown): unknown {
+    if (typeof value === 'bigint') {
+      return serializeBigInt(value)
+    }
+    if (value instanceof Uint8Array) {
+      return uint8ArrayToBase85(value)
+    }
     if (value instanceof Set) {
       return Array.from(value.keys())
     }
@@ -74,23 +71,13 @@ export class AwstSerializer<T> extends SnakeCaseSerializer<T> {
       }
       return Array.from(value.entries())
     }
-    if (value instanceof Uint8Array) {
-      return super.serializerFunction(key, value)
-    }
     if (value instanceof ContractReference || value instanceof LogicSigReference) {
       return value.toString()
     }
     if (value instanceof IntrinsicCall) {
-      // Convert bigint immediates to number so they serialize without quotes and can be disambiguated from string immediates
       return {
         _type: IntrinsicCall.name,
         ...(super.serializerFunction(key, value) as object),
-        immediates: value.immediates.map((i) => {
-          if (typeof i === 'bigint') {
-            return serializeBigInt(i)
-          }
-          return i
-        }),
       }
     }
     if (value instanceof AbsolutePath) {

--- a/src/awst/wtypes.ts
+++ b/src/awst/wtypes.ts
@@ -248,16 +248,15 @@ export namespace wtypes {
   export class ARC4Tuple extends ARC4Type {
     readonly types: WType[]
     readonly sourceLocation: SourceLocation | null
-    readonly immutable: boolean
 
     constructor({ types, sourceLocation, immutable }: { types: WType[]; sourceLocation?: SourceLocation; immutable: boolean }) {
       const typesStr = types.map((t) => t.name).join(',')
       super({
         name: `arc4.tuple<${typesStr}>`,
+        immutable,
       })
       this.sourceLocation = sourceLocation ?? null
       this.types = types
-      this.immutable = immutable
     }
   }
 

--- a/src/awst_build/eb/index.ts
+++ b/src/awst_build/eb/index.ts
@@ -152,7 +152,7 @@ export abstract class InstanceBuilder<TPType extends PType = PType> extends Node
     }
     return instanceEb(
       nodeFactory.singleEvaluation({
-        source: this.resolve(),
+        source: expr,
       }),
       this.ptype,
     )

--- a/src/util/base-85.ts
+++ b/src/util/base-85.ts
@@ -17,38 +17,26 @@ function* batchBytesToUintN(bytes: Uint8Array, n: number): Generator<bigint> {
   }
 }
 
+const b85Alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+-;<=>?@^_`{|}~'
+const b85Chars = b85Alphabet.split('')
+const b85DoubleChars = b85Chars.flatMap((c) => b85Chars.map((c2) => c + c2))
+
 /**
  * This implementation of base85 encoding matches python's base64.b85encode(...) function which is based on the character set of rfc1924
  * but supports arbitrary sized input.
  *
  * It IS NOT an ascii85 implementation
  */
-export function buildBase85Encoder() {
-  const b85Alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!#$%&()*+-;<=>?@^_`{|}~'
-  const b85Chars = b85Alphabet.split('')
-  const b85DoubleChars = b85Chars.flatMap((c) => b85Chars.map((c2) => c + c2))
-
-  function encode(b: Uint8Array, chars: string[], doubleChars: string[]) {
-    const padding = positiveMod(-b.length, 4)
-    if (padding) {
-      b = new Uint8Array([...b, ...repeat(0, padding)])
-    }
-    let result = ''
-    for (const word of batchBytesToUintN(b, 4 * 8)) {
-      result += doubleChars[Number(word / 85n ** 3n)]
-      result += doubleChars[Number((word / 85n) % 85n ** 2n)]
-      result += chars[Number(word % 85n)]
-    }
-    return result.slice(0, result.length - padding)
+export function uint8ArrayToBase85(b: Uint8Array) {
+  const padding = positiveMod(-b.length, 4)
+  if (padding) {
+    b = new Uint8Array([...b, ...repeat(0, padding)])
   }
-
-  return {
-    encode(b: Uint8Array) {
-      return encode(b, b85Chars, b85DoubleChars)
-    },
-    encodeUtf8(s: string) {
-      const b = new TextEncoder().encode(s)
-      return this.encode(b)
-    },
+  let result = ''
+  for (const word of batchBytesToUintN(b, 4 * 8)) {
+    result += b85DoubleChars[Number(word / 85n ** 3n)]
+    result += b85DoubleChars[Number((word / 85n) % 85n ** 2n)]
+    result += b85Chars[Number(word % 85n)]
   }
+  return result.slice(0, result.length - padding)
 }


### PR DESCRIPTION
*also*:

- remove extra `.resolve()` call in `singleEvaluation` method of `InstanceBuilder`
- remove extra redeclaratino fo `immutable` property in `ARC4Tuple` wtype