### PR TITLE
docs: render language guide table of contents as link cards

### DIFF
--- a/docs/src/content/docs/language-guide/index.mdx
+++ b/docs/src/content/docs/language-guide/index.mdx
@@ -2,6 +2,8 @@
 title: Algorand TypeScript Language Guide
 ---
 
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
 # Algorand TypeScript Language Guide
 
 Algorand TypeScript is a partial implementation of the TypeScript programming language that runs on the Algorand Virtual Machine (AVM). It defines a library of types, classes, and functions to facilitate the development of smart contracts and logic signatures for the Algorand blockchain.
@@ -22,8 +24,30 @@ If you are interested in learning about the design of Algorand TypeScript, you c
 
 ## Table of Contents
 
-- [Program Structure](./program-structure)
-- [Basic Types](./types)
-- [Storage](./storage)
-- [Ops](./ops)
-- [Inner Transactions](./itxns)
+<CardGrid>
+  <LinkCard
+    title="Program Structure"
+    href="./program-structure/"
+    description="How an Algorand TypeScript program is declared across modules, and how contracts and logic signatures are discovered and output."
+  />
+  <LinkCard
+    title="Basic Types"
+    href="./types/"
+    description="Native AVM types and ARC4 encoded types, and how to choose between them."
+  />
+  <LinkCard
+    title="Storage"
+    href="./storage/"
+    description="Persisting state with global, local, and box storage, plus transient scratch space."
+  />
+  <LinkCard
+    title="Ops"
+    href="./ops/"
+    description="Express AVM opcodes directly from TypeScript via the ops module."
+  />
+  <LinkCard
+    title="Inner Transactions"
+    href="./itxns/"
+    description="Construct and submit inner transactions from within a contract using the itxn namespace."
+  />
+</CardGrid>


### PR DESCRIPTION
Currently, the Table of Contents for the Language Guide are broken because of the deployment changes in DevPortal which haven't been pushed to prod yet. 

This converts the ToC from a plain bullet list into a `<CardGrid>` of Starlight `<LinkCard>`s, each with a short description. The cards are more scannable and visually consistent with the rest of the docs landing pages.

This requires changing the page from `.md` to `.mdx` so it can import the Starlight components (matching the existing pattern used by the docs root `index.mdx`).

## Notes

- Card `href`s are **relative** (`./program-structure/`, etc.), so they resolve correctly both on the standalone docs site (base `/puya-ts/`) and when these docs are imported into the Algorand Dev Portal (`/docs/algorand-typescript/.../language-guide/`).
- Verified with a clean `astro build` on this repo, and by building the Dev Portal with the imported page in place.